### PR TITLE
ManagedServiceInstance.delete has to pass the current version to wait_for_state

### DIFF
--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -231,7 +231,7 @@ class ManagedServiceInstance:
             version=version,
             versions=versions,
             bad_states=bad_states,
-            start_version=current_version
+            start_version=current_version,
         )
 
     def get_state(


### PR DESCRIPTION
# Description

When calling `wait_for_state`, ManagedServiceInstance.delete has to pass the current version, otherwise the current state can be mistaken for a bad one (if the current state is up, and up is in the bad states as well for example).

closes #70 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
