### PR TITLE
set up for 1.0.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 1.0.0
 tag = False
 commit = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v 0.2.0 (?)
+# v 1.0.0 (?)
 Changes in this release:
 
 # v 0.1.0 (2020-11-10)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-inmanta-lsm",
-    version="0.2.0",
+    version="1.0.0",
     python_requires=">=3.6",  # also update classifiers
     author="Inmanta",
     author_email="code@inmanta.com",
@@ -27,7 +27,7 @@ setup(
     package_dir={"": "src"},
     install_requires=["pytest-inmanta", "inmanta-lsm"],
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Framework :: Pytest",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Running the release job for a major release would not work for a 1.0.0 because it does not set "Development Status" in setup.py.