### PR TITLE
allow testing against iso4 and iso5

### DIFF
--- a/.ci-integration-tests-iso4.yml
+++ b/.ci-integration-tests-iso4.yml
@@ -5,7 +5,7 @@ lock:
     variable: INMANTA_LSM_HOST
     quantity: 1
 additional_constraints:
-    - inmanta-lsm~=1.6
+    - inmanta-lsm~=1.6.dev
 directories_to_lint:
     - examples
     - src

--- a/.ci-integration-tests-iso4.yml
+++ b/.ci-integration-tests-iso4.yml
@@ -1,0 +1,12 @@
+pipeline_template: ci/inmanta-tools/Jenkinsfile-integration-tests
+repo_name: pytest-inmanta-lsm
+lock:
+    label: pytest-inmanta-lsm-iso4-dev
+    variable: INMANTA_LSM_HOST
+    quantity: 1
+additional_constraints:
+    - inmanta-lsm~=1.6
+directories_to_lint:
+    - examples
+    - src
+    - tests

--- a/.ci-integration-tests-iso5.yml
+++ b/.ci-integration-tests-iso5.yml
@@ -5,7 +5,7 @@ lock:
     variable: INMANTA_LSM_HOST
     quantity: 1
 additional_constraints:
-    - inmanta-lsm~=2.0
+    - inmanta-lsm~=2.0.dev
 directories_to_lint:
     - examples
     - src

--- a/.ci-integration-tests-iso5.yml
+++ b/.ci-integration-tests-iso5.yml
@@ -1,9 +1,11 @@
 pipeline_template: ci/inmanta-tools/Jenkinsfile-integration-tests
 repo_name: pytest-inmanta-lsm
 lock:
-    label: iso3-test
+    label: pytest-inmanta-lsm-iso5-dev
     variable: INMANTA_LSM_HOST
     quantity: 1
+additional_constraints:
+    - inmanta-lsm~=2.0
 directories_to_lint:
     - examples
     - src


### PR DESCRIPTION
# Description

Set up separate ci configs for testing against iso4 and iso5. See #919 for irt support.

- [iso4 pipeline](https://jenkins.inmanta.com/job/development-tools/job/pytest-inmanta-lsm-iso4/)
- [iso5 pipeline](https://jenkins.inmanta.com/job/development-tools/job/pytest-inmanta-lsm-iso5/)
- orchestrator setup: http://mgmt.ii.inmanta.com:8888/console/lsm/catalog/test-orchestrator/inventory?env=f81be80b-8582-499f-b002-7cdd2f2df98a
- After merging I'll disable the old job and add the new ones to the traffic light.

closes #166

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
