### PR TITLE
Project install use server env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 1.5.0 (?)
 Changes in this release:
 
-# v 1.4.1 (2022-02-09)
+# v 1.4.1 (2022-02-10)
 Changes in this release:
 - Run project installation with server's environment variables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 1.5.0 (?)
 Changes in this release:
 
+# v 1.4.1 (2022-02-08)
+Changes in this release:
+- Run project installation with server's environment variables
+
 # v 1.4.0 (2022-02-07)
 Changes in this release:
 - Compatibility with `inmanta-service-orchestrator>=5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 1.5.0 (?)
 Changes in this release:
 
-# v 1.4.1 (2022-02-08)
+# v 1.4.1 (2022-02-09)
 Changes in this release:
 - Run project installation with server's environment variables
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -99,8 +99,8 @@ class RemoteOrchestrator:
 
     def export_service_entities(self) -> None:
         """Initialize the remote orchestrator with the service model and check if all preconditions hold"""
-        self.sync_project()
         self._project._exporter.run_export_plugin("service_entities_exporter")
+        self.sync_project()
 
     def _ensure_environment(self) -> None:
         """Make sure the environment exists"""

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -253,7 +253,7 @@ class RemoteOrchestrator:
             )
             shell_script_inline: str = (
                 # use the server's environment variables for the installation
-                "sudo systemd-run User=inmanta EnvironmentFile=/etc/sysconfig/inmanta-server"
+                "sudo systemd-run -p User=inmanta -p EnvironmentFile=/etc/sysconfig/inmanta-server --wait"
                 " /opt/inmanta/bin/python -c %s" % shlex.quote(python_script_inline)
             )
             subprocess.check_output(

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -252,9 +252,8 @@ class RemoteOrchestrator:
                 "project.install_modules();"
             )
             shell_script_inline: str = (
-                "sudo -u inmanta"
-                # set the environment for this command to run in, remove comments
-                " env $(sed 's/#.*$//' /etc/sysconfig/inmanta-server)"
+                # use the server's environment variables for the installation
+                "sudo systemd-run User=inmanta EnvironmentFile=/etc/sysconfig/inmanta-server"
                 " /opt/inmanta/bin/python -c %s" % shlex.quote(python_script_inline)
             )
             subprocess.check_output(

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -255,8 +255,7 @@ class RemoteOrchestrator:
                 "sudo -u inmanta"
                 # set the environment for this command to run in, remove comments
                 " env $(sed 's/#.*$//' /etc/sysconfig/inmanta-server)"
-                " /opt/inmanta/bin/python -c %s"
-                % shlex.quote(python_script_inline)
+                " /opt/inmanta/bin/python -c %s" % shlex.quote(python_script_inline)
             )
             subprocess.check_output(
                 SSH_CMD

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -256,15 +256,20 @@ class RemoteOrchestrator:
                 "sudo systemd-run -p User=inmanta -p EnvironmentFile=/etc/sysconfig/inmanta-server --wait"
                 " /opt/inmanta/bin/python -c %s" % shlex.quote(python_script_inline)
             )
-            subprocess.check_output(
-                SSH_CMD
-                + [
-                    f"-p {self._ssh_port}",
-                    f"{self._ssh_user}@{self.host}",
-                    shell_script_inline,
-                ],
-                stderr=subprocess.PIPE,
-            )
+            try:
+                subprocess.check_output(
+                    SSH_CMD
+                    + [
+                        f"-p {self._ssh_port}",
+                        f"{self._ssh_user}@{self.host}",
+                        shell_script_inline,
+                    ],
+                    stderr=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as e:
+                LOGGER.error("Process failed out: " + e.output.decode())
+                LOGGER.error("Process failed err: " + e.stderr.decode())
+                raise
 
         # Server cache create, set variables, so cache can be used
         self._server_path = server_path


### PR DESCRIPTION
# Description

The project install introduced in 1.4.0 did not use the server's env vars configured in `/etc/sysconfig/inmanta-server` into account. This PR runs the installation script inside a transient unit with the same `EnvironmentFile` as the inmanta server.

closes #183 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
