### PR TITLE
migrate iso4 ci to rocky host

### DIFF
--- a/.ci-integration-tests-iso4.yml
+++ b/.ci-integration-tests-iso4.yml
@@ -6,6 +6,8 @@ lock:
     quantity: 1
 additional_constraints:
     - inmanta-lsm~=1.6.dev
+env_vars:
+    INMANTA_LSM_USER: rocky
 directories_to_lint:
     - examples
     - src


### PR DESCRIPTION
I recreated the iso4 test orchestrator. It is now a rocky host.