### PR TITLE
Issue/186 add support for ssl and auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v 1.5.0 (?)
 Changes in this release:
 
+# v 1.4.2 (2022-02-25)
+Changes in this release:
+- Add support for SSL and anthentication (#186)
+
 # v 1.4.1 (2022-02-10)
 Changes in this release:
 - Run project installation with server's environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # v 1.5.0 (?)
 Changes in this release:
-
-# v 1.4.2 (2022-02-25)
-Changes in this release:
 - Add support for SSL and anthentication (#186)
 
 # v 1.4.1 (2022-02-10)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following options are available.
  * `--lsm_port` port to use to ssh to the remote orchestrator, overrides INMANTA_LSM_PORT
  * `--lsm_environment` the environment to use on the remote server (it is created if it doesn't exist), overrides INMANTA_LSM_ENVIRONMENT
  * `--lsm_noclean` Don't cleanup the orchestrator after last test (for debugging purposes)
- * `--lsm_ssl` Connect to the remote orchestrator using SSL/TLS
- * `--lsm_token` The token used to authenticate to the remote orchestrator when authentication is enabled.
- * `--lsm_ca_cert` The path to the CA certificate file used to authenticate the remote orchestrator.
+ * `--lsm_ssl` Connect to the remote orchestrator using SSL/TLS, overrides INMANTA_LSM_SSL
+ * `--lsm_token` The token used to authenticate to the remote orchestrator when authentication is enabled, overrides INMANTA_LSM_TOKEN
+ * `--lsm_ca_cert` The path to the CA certificate file used to authenticate the remote orchestrator, overrides INMANTA_LSM_CA_CERT
  

--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ The following options are available.
  * `--lsm_port` port to use to ssh to the remote orchestrator, overrides INMANTA_LSM_PORT
  * `--lsm_environment` the environment to use on the remote server (it is created if it doesn't exist), overrides INMANTA_LSM_ENVIRONMENT
  * `--lsm_noclean` Don't cleanup the orchestrator after last test (for debugging purposes)
+ * `--ssl` Use SSL
+ * `--token` The token to use when using SSL
+ * `--ca_cert` The certificate to use when performing authentication

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following options are available.
  * `--lsm_port` port to use to ssh to the remote orchestrator, overrides INMANTA_LSM_PORT
  * `--lsm_environment` the environment to use on the remote server (it is created if it doesn't exist), overrides INMANTA_LSM_ENVIRONMENT
  * `--lsm_noclean` Don't cleanup the orchestrator after last test (for debugging purposes)
- * `--ssl` Use SSL
- * `--token` The token to use when using SSL
- * `--ca_cert` The certificate to use when performing authentication
+ * `--lsm_ssl` Connect to the remote orchestrator using SSL/TLS
+ * `--lsm_token` The token used to authenticate to the remote orchestrator when authentication is enabled.
+ * `--lsm_ca_cert` The path to the CA certificate file used to authenticate the remote orchestrator.
+ 

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -120,7 +120,7 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
 
     if ssl:
         if not os.path.isfile(ca_cert):
-            raise FileNotFoundError("Invalid path to CA certificate file")
+            raise FileNotFoundError(f"Invalid path to CA certificate file: {ca_cert}")
         ca_cert = os.path.abspath(ca_cert)
     else:
         if ca_cert:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -122,6 +122,10 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
         if not os.path.isfile(ca_cert):
             raise FileNotFoundError("Invalid path to CA certificate file")
         ca_cert = os.path.abspath(ca_cert)
+    else:
+        if ca_cert:
+            LOGGER.warning("ssl option is set to False, so the CA certificate won't be used")
+
 
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -126,7 +126,6 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
         if ca_cert:
             LOGGER.warning("ssl option is set to False, so the CA certificate won't be used")
 
-
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
         "auto_deploy": True,

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -115,8 +115,8 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
     port = get_opt_or_env_or(request.config, "inm_lsm_remote_port", "22")
     noclean = get_opt_or_env_or(request.config, "inm_lsm_noclean", "false").lower() == "true"
     ssl = get_opt_or_env_or(request.config, "inm_lsm_ssl", "false").lower() == "true"
-    token = get_opt_or_env_or(request.config, "inm_lsm_token")
-    ca_cert = get_opt_or_env_or(request.config, "inm_lsm_ca_cert")
+    token = get_opt_or_env_or(request.config, "inm_lsm_token", None)
+    ca_cert = get_opt_or_env_or(request.config, "inm_lsm_ca_cert", None)
 
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -36,9 +36,9 @@ option_to_env = {
     "inm_lsm_remote_port": "INMANTA_LSM_PORT",
     "inm_lsm_env": "INMANTA_LSM_ENVIRONMENT",
     "inm_lsm_noclean": "INMANTA_LSM_NOCLEAN",
-    "inm_ssl": "INMANTA_SSL",
-    "inm_token": "INMANTA_TOKEN",
-    "inm_ca_cert": "INMANTA_CA_CERT",
+    "inm_lsm_ssl": "INMANTA_LSM_SSL",
+    "inm_lsm_token": "INMANTA_LSM_TOKEN",
+    "inm_lsm_ca_cert": "INMANTA_LSM_CA_CERT",
 }
 
 
@@ -47,22 +47,22 @@ def pytest_addoption(parser):
     group.addoption(
         "--lsm_host",
         dest="inm_lsm_remote_host",
-        help="remote orchestrator to use for the remote_inmanta fixture, overrides INMANTA_LSM_HOST",
+        help="Remote orchestrator to use for the remote_inmanta fixture, overrides INMANTA_LSM_HOST",
     )
     group.addoption(
         "--lsm_user",
         dest="inm_lsm_remote_user",
-        help="username to use to ssh to the remote orchestrator, overrides INMANTA_LSM_USER",
+        help="Username to use to ssh to the remote orchestrator, overrides INMANTA_LSM_USER",
     )
     group.addoption(
         "--lsm_port",
         dest="inm_lsm_remote_port",
-        help="port to use to ssh to the remote orchestrator, overrides INMANTA_LSM_PORT",
+        help="Port to use to ssh to the remote orchestrator, overrides INMANTA_LSM_PORT",
     )
     group.addoption(
         "--lsm_environment",
         dest="inm_lsm_env",
-        help="the environment to use on the remote server (is created if it doesn't exist), overrides INMANTA_LSM_ENVIRONMENT",
+        help="The environment to use on the remote server (is created if it doesn't exist), overrides INMANTA_LSM_ENVIRONMENT",
     )
     group.addoption(
         "--lsm_noclean",
@@ -70,19 +70,19 @@ def pytest_addoption(parser):
         help="Don't cleanup the orchestrator after tests (for debugging purposes)",
     )
     group.addoption(
-        "--ssl",
-        dest="inm_ssl",
-        help="Use SSL",
+        "--lsm_ssl",
+        dest="inm_lsm_ssl",
+        help="Connect to the remote orchestrator using SSL/TLS",
     )
     group.addoption(
-        "--token",
-        dest="inm_token",
-        help="the token to use when using SSL, overrides INMANTA_TOKEN",
+        "--lsm_token",
+        dest="inm_lsm_token",
+        help="The token used to authenticate to the remote orchestrator when authentication is enabled, overrides INMANTA_LSM_TOKEN",  # NOQA E501
     )
     group.addoption(
-        "--ca_cert",
-        dest="inm_ca_cert",
-        help="the certificate to use when performing authentication, overrides INMANTA_CA_CERT",
+        "--lsm_ca_cert",
+        dest="inm_lsm_ca_cert",
+        help="The path to the CA certificate file used to authenticate the remote orchestrator, overrides INMANTA_LSM_CA_CERT",
     )
 
 
@@ -114,9 +114,9 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
     user = get_opt_or_env_or(request.config, "inm_lsm_remote_user", "centos")
     port = get_opt_or_env_or(request.config, "inm_lsm_remote_port", "22")
     noclean = get_opt_or_env_or(request.config, "inm_lsm_noclean", "false").lower() == "true"
-    ssl = get_opt_or_env_or(request.config, "inm_ssl", "false")
-    token = get_opt_or_env_or(request.config, "inm_token", "admin")
-    ca_cert = get_opt_or_env_or(request.config, "inm_ca_cert", "admin")
+    ssl = get_opt_or_env_or(request.config, "inm_lsm_ssl", "false").lower() == "true"
+    token = get_opt_or_env_or(request.config, "inm_lsm_token")
+    ca_cert = get_opt_or_env_or(request.config, "inm_lsm_ca_cert")
 
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -72,7 +72,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--lsm_ssl",
         dest="inm_lsm_ssl",
-        help="Connect to the remote orchestrator using SSL/TLS",
+        help="[True | False] Choose whether to use SSL/TLS or not when connecting to the remote orchestrator, overrides INMANTA_LSM_SSL",
     )
     group.addoption(
         "--lsm_token",

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -72,7 +72,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--lsm_ssl",
         dest="inm_lsm_ssl",
-        help="[True | False] Choose whether to use SSL/TLS or not when connecting to the remote orchestrator, overrides INMANTA_LSM_SSL",
+        help="[True | False] Choose whether to use SSL/TLS or not when connecting to the remote orchestrator, overrides INMANTA_LSM_SSL",  # NOQA E501
     )
     group.addoption(
         "--lsm_token",

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -9,7 +9,7 @@
 import logging
 import os
 import os.path
-from typing import Dict, Iterator, Union
+from typing import Dict, Iterator, Optional, Union
 from uuid import UUID
 
 import pytest
@@ -86,7 +86,7 @@ def pytest_addoption(parser):
     )
 
 
-def get_opt_or_env_or(config, key: str, default: str) -> str:
+def get_opt_or_env_or(config, key: str, default: Optional[str]) -> Optional[str]:
     if config.getoption(key):
         return config.getoption(key)
     if option_to_env[key] in os.environ:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -118,6 +118,11 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
     token = get_opt_or_env_or(request.config, "inm_lsm_token", None)
     ca_cert = get_opt_or_env_or(request.config, "inm_lsm_ca_cert", None)
 
+    if ssl:
+        if not os.path.isfile(ca_cert):
+            raise FileNotFoundError("Invalid path to CA certificate file")
+        ca_cert = os.path.abspath(ca_cert)
+
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
         "auto_deploy": True,

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -36,6 +36,9 @@ option_to_env = {
     "inm_lsm_remote_port": "INMANTA_LSM_PORT",
     "inm_lsm_env": "INMANTA_LSM_ENVIRONMENT",
     "inm_lsm_noclean": "INMANTA_LSM_NOCLEAN",
+    "inm_ssl": "INMANTA_SSL",
+    "inm_token": "INMANTA_TOKEN",
+    "inm_ca_cert": "INMANTA_CA_CERT",
 }
 
 
@@ -65,6 +68,21 @@ def pytest_addoption(parser):
         "--lsm_noclean",
         dest="inm_lsm_noclean",
         help="Don't cleanup the orchestrator after tests (for debugging purposes)",
+    )
+    group.addoption(
+        "--ssl",
+        dest="inm_ssl",
+        help="Use SSL",
+    )
+    group.addoption(
+        "--token",
+        dest="inm_token",
+        help="the token to use when using SSL, overrides INMANTA_TOKEN",
+    )
+    group.addoption(
+        "--ca_cert",
+        dest="inm_ca_cert",
+        help="the certificate to use when performing authentication, overrides INMANTA_CA_CERT",
     )
 
 
@@ -96,6 +114,9 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
     user = get_opt_or_env_or(request.config, "inm_lsm_remote_user", "centos")
     port = get_opt_or_env_or(request.config, "inm_lsm_remote_port", "22")
     noclean = get_opt_or_env_or(request.config, "inm_lsm_noclean", "false").lower() == "true"
+    ssl = get_opt_or_env_or(request.config, "inm_ssl", "false")
+    token = get_opt_or_env_or(request.config, "inm_token", "admin")
+    ca_cert = get_opt_or_env_or(request.config, "inm_ca_cert", "admin")
 
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
@@ -118,6 +139,9 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
         project=project,
         settings=settings,
         noclean=noclean,
+        ssl=ssl,
+        token=token,
+        ca_cert=ca_cert,
     )
     remote_orchestrator.clean()
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -45,6 +45,9 @@ class RemoteOrchestrator:
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
         ssh_port: str = "22",
+        ssl: str = "false",
+        token: str = "admin",
+        ca_cert: str = "admin",
     ) -> None:
         """
         Utility object to manage a remote orchestrator and integrate with pytest-inmanta
@@ -57,6 +60,9 @@ class RemoteOrchestrator:
         :param settings: The inmanta environment settings that should be set on the remote orchestrator
         :param noclean: Option to indicate that after the run clean should not run. This exposes the attribute to other
                         fixtures.
+        :param ssl: Option to indicate wether SSL should be used or not. Defaults to false
+        :param token: Token used for authentication
+        :param ca_cert: Certificate used for authentication
         """
         self._env = environment
         self._host = host
@@ -64,13 +70,22 @@ class RemoteOrchestrator:
         self._ssh_port = ssh_port
         self._settings = settings
         self.noclean = noclean
+        self._ssl = ssl
+        self._token = token
+        self._ca_cert = ca_cert
 
         inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self._env))
-        inmanta_config.Config.set("compiler_rest_transport", "host", host)
-        inmanta_config.Config.set("compiler_rest_transport", "port", "8888")
-        inmanta_config.Config.set("client_rest_transport", "host", host)
-        inmanta_config.Config.set("client_rest_transport", "port", "8888")
+
+        for section in ["compiler_rest_transport", "client_rest_transport"]:
+            inmanta_config.Config.set(section, "host", host)
+            inmanta_config.Config.set(section, "port", "8888")
+
+            # Config for SSL and authentication:
+            inmanta_config.Config.set(section, "inm_ssl", ssl)
+            inmanta_config.Config.set(section, "inm_token", token)
+            inmanta_config.Config.set(section, "inm_ca_cert", ca_cert)
+
 
         self._project = project
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -142,7 +142,7 @@ class RemoteOrchestrator:
             result = client.project_create(name=project_name)
             assert (
                 result.code == 200
-            ), f"Wrong reponse code while creating project, got {result.code} (expected 200): \n{result}"
+            ), f"Wrong reponse code while creating project, got {result.code} (expected 200): \n{result.result}"
             return result.result["data"]["id"]
 
         result = client.create_environment(
@@ -152,7 +152,7 @@ class RemoteOrchestrator:
         )
         assert (
             result.code == 200
-        ), f"Wrong response code while creating environment, got {result.code} (expected 200): \n{result}"
+        ), f"Wrong response code while creating environment, got {result.code} (expected 200): \n{result.result}"
 
     def sync_project(self) -> None:
         """Synchronize the project to the lab orchestrator"""

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -86,7 +86,6 @@ class RemoteOrchestrator:
             inmanta_config.Config.set(section, "inm_token", token)
             inmanta_config.Config.set(section, "inm_ca_cert", ca_cert)
 
-
         self._project = project
 
         self._client: Optional[SyncClient] = None

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -84,10 +84,10 @@ class RemoteOrchestrator:
             # Config for SSL and authentication:
             if ssl:
                 inmanta_config.Config.set(section, "ssl", str(ssl))
-                if token:
-                    inmanta_config.Config.set(section, "token", token)
                 if ca_cert:
                     inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
+            if token:
+                inmanta_config.Config.set(section, "token", token)
 
         self._project = project
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -44,10 +44,10 @@ class RemoteOrchestrator:
         project: Project,
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
+        token: str,
+        ca_cert: str,
         ssh_port: str = "22",
         ssl: bool = False,
-        token: str = "admin",
-        ca_cert: str = "admin",
     ) -> None:
         """
         Utility object to manage a remote orchestrator and integrate with pytest-inmanta
@@ -60,7 +60,7 @@ class RemoteOrchestrator:
         :param settings: The inmanta environment settings that should be set on the remote orchestrator
         :param noclean: Option to indicate that after the run clean should not run. This exposes the attribute to other
                         fixtures.
-        :param ssl: Option to indicate wether SSL should be used or not. Defaults to false
+        :param ssl: Option to indicate whether SSL should be used or not. Defaults to false
         :param token: Token used for authentication
         :param ca_cert: Certificate used for authentication
         """
@@ -82,7 +82,7 @@ class RemoteOrchestrator:
             inmanta_config.Config.set(section, "port", "8888")
 
             # Config for SSL and authentication:
-            inmanta_config.Config.set(section, "ssl", ssl)
+            inmanta_config.Config.set(section, "ssl", str(ssl))
             inmanta_config.Config.set(section, "token", token)
             inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -82,9 +82,10 @@ class RemoteOrchestrator:
             inmanta_config.Config.set(section, "port", "8888")
 
             # Config for SSL and authentication:
-            inmanta_config.Config.set(section, "ssl", str(ssl))
-            inmanta_config.Config.set(section, "token", token)
-            inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
+            if ssl:
+                inmanta_config.Config.set(section, "ssl", str(ssl))
+                inmanta_config.Config.set(section, "token", token)
+                inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
 
         self._project = project
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -84,8 +84,10 @@ class RemoteOrchestrator:
             # Config for SSL and authentication:
             if ssl:
                 inmanta_config.Config.set(section, "ssl", str(ssl))
-                inmanta_config.Config.set(section, "token", token)
-                inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
+                if token:
+                    inmanta_config.Config.set(section, "token", token)
+                if ca_cert:
+                    inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
 
         self._project = project
 
@@ -132,7 +134,7 @@ class RemoteOrchestrator:
             result = client.project_list()
             assert (
                 result.code == 200
-            ), f"Wrong reponse code while verifying project, got {result.code} (expected 200): \n{result}"
+            ), f"Wrong reponse code while verifying project, got {result.code} (expected 200): \n{result.result}"
             for project in result.result["data"]:
                 if project["name"] == project_name:
                     return project["id"]

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -44,9 +44,9 @@ class RemoteOrchestrator:
         project: Project,
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
-        token: Optional[str],
-        ca_cert: Optional[str],
         ssh_port: str = "22",
+        token: Optional[str] = None,
+        ca_cert: Optional[str] = None,
         ssl: bool = False,
     ) -> None:
         """

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -44,8 +44,8 @@ class RemoteOrchestrator:
         project: Project,
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
-        token: str,
-        ca_cert: str,
+        token: Optional[str],
+        ca_cert: Optional[str],
         ssh_port: str = "22",
         ssl: bool = False,
     ) -> None:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -45,7 +45,7 @@ class RemoteOrchestrator:
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
         ssh_port: str = "22",
-        ssl: str = "false",
+        ssl: bool = False,
         token: str = "admin",
         ca_cert: str = "admin",
     ) -> None:
@@ -82,9 +82,9 @@ class RemoteOrchestrator:
             inmanta_config.Config.set(section, "port", "8888")
 
             # Config for SSL and authentication:
-            inmanta_config.Config.set(section, "inm_ssl", ssl)
-            inmanta_config.Config.set(section, "inm_token", token)
-            inmanta_config.Config.set(section, "inm_ca_cert", ca_cert)
+            inmanta_config.Config.set(section, "ssl", ssl)
+            inmanta_config.Config.set(section, "token", token)
+            inmanta_config.Config.set(section, "ssl_ca_cert_file", ca_cert)
 
         self._project = project
 


### PR DESCRIPTION
# Description

~~First steps towards adding support for SSL and authentication.
I didn't change anything in the inmanta-core repo even though https://github.com/inmanta/inmanta-core/blob/master/tests/conftest.py#L712 is referenced in the issue~~

Add support for SSL and authentication

closes #186 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
~~- [ ] Changelog entry~~
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
