### PR TITLE
Issue/192 support iso5 containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.5.0 (?)
 Changes in this release:
+- Add support for iso5 container environment (#192)
 - Add support for SSL and anthentication (#186)
 
 # v 1.4.1 (2022-02-10)

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -321,7 +321,7 @@ class ManagedServiceInstance:
                     # Version is not given, so version does not need to be verified
                     return True
                 elif current_state.version not in desired_versions:
-                    raise VersionMismatchError(self, desired_versions, current_state.version)
+                    raise VersionMismatchError(self, desired_versions, current_state.version or 0)
                 else:
                     return True
             elif (

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -321,7 +321,7 @@ class ManagedServiceInstance:
                     # Version is not given, so version does not need to be verified
                     return True
                 elif current_state.version not in desired_versions:
-                    raise VersionMismatchError(self, desired_versions, current_state.version or 0)
+                    raise VersionMismatchError(self, desired_versions, current_state.version)
                 else:
                     return True
             elif (

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -74,9 +74,9 @@ def pytest_addoption(parser):
         "--lsm_container_env",
         dest="inm_lsm_container_env",
         help=(
-            "If set to true, expect the the orchestrator to be running in a container without systemd.  "
+            "If set to true, expect the orchestrator to be running in a container without systemd.  "
             "It then assumes that all environment variables required to install the modules are loaded into "
-            "each ssh session automatically."
+            "each ssh session automatically.  Overrides INMANTA_LSM_CONTAINER_ENV."
         ),
     )
     group.addoption(
@@ -164,10 +164,10 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
         project=project,
         settings=settings,
         noclean=noclean,
-        container_env=container_env,
         ssl=ssl,
         token=token,
         ca_cert=ca_cert,
+        container_env=container_env,
     )
     remote_orchestrator.clean()
 

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -36,6 +36,7 @@ option_to_env = {
     "inm_lsm_remote_port": "INMANTA_LSM_PORT",
     "inm_lsm_env": "INMANTA_LSM_ENVIRONMENT",
     "inm_lsm_noclean": "INMANTA_LSM_NOCLEAN",
+    "inm_lsm_container_env": "INMANTA_LSM_CONTAINER_ENV",
 }
 
 
@@ -65,6 +66,15 @@ def pytest_addoption(parser):
         "--lsm_noclean",
         dest="inm_lsm_noclean",
         help="Don't cleanup the orchestrator after tests (for debugging purposes)",
+    )
+    group.addoption(
+        "--lsm_container_env",
+        dest="inm_lsm_container_env",
+        help=(
+            "If set to true, expect the the orchestrator to be running in a container without systemd.  "
+            "It then assumes that all environment variables required to install the modules are loaded into "
+            "each ssh session automatically."
+        ),
     )
 
 
@@ -96,6 +106,7 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
     user = get_opt_or_env_or(request.config, "inm_lsm_remote_user", "centos")
     port = get_opt_or_env_or(request.config, "inm_lsm_remote_port", "22")
     noclean = get_opt_or_env_or(request.config, "inm_lsm_noclean", "false").lower() == "true"
+    container_env = get_opt_or_env_or(request.config, "inm_lsm_container_env", "false").lower() == "true"
 
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
@@ -118,6 +129,7 @@ def remote_orchestrator(project: Project, request, remote_orchestrator_settings)
         project=project,
         settings=settings,
         noclean=noclean,
+        container_env=container_env,
     )
     remote_orchestrator.clean()
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -45,10 +45,10 @@ class RemoteOrchestrator:
         settings: Dict[str, Union[bool, str, int]],
         noclean: bool,
         ssh_port: str = "22",
-        container_env: bool = False,
         token: Optional[str] = None,
         ca_cert: Optional[str] = None,
         ssl: bool = False,
+        container_env: bool = False,
     ) -> None:
         """
         Utility object to manage a remote orchestrator and integrate with pytest-inmanta
@@ -64,6 +64,7 @@ class RemoteOrchestrator:
         :param ssl: Option to indicate whether SSL should be used or not. Defaults to false
         :param token: Token used for authentication
         :param ca_cert: Certificate used for authentication
+        :param container_env: Whether the remote orchestrator is running in a container, without a systemd init process.
         """
         self._env = environment
         self._host = host
@@ -71,10 +72,10 @@ class RemoteOrchestrator:
         self._ssh_port = ssh_port
         self._settings = settings
         self.noclean = noclean
-        self.container_env = container_env
         self._ssl = ssl
         self._token = token
         self._ca_cert = ca_cert
+        self.container_env = container_env
 
         inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self._env))


### PR DESCRIPTION
# Description

Add option to tell pytest-inmanta-lsm it will be reaching an orchestrator in a container, which doesn't have a systemd process running in it.

closes #192 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
