### PR TITLE
Issue/118 use diagnose endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.7.0 (?)
 Changes in this release:
-- Improve logging for containerized orchestrator setup
+- Improve logging for containerized orchestrator setup.
+- Use the diagnose endpoint to generate the validation/deployment failure reports.
 
 # v 1.6.1 (2022-05-18)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/failed_resources_logs.py
+++ b/src/pytest_inmanta_lsm/failed_resources_logs.py
@@ -19,9 +19,12 @@ class FailedResourcesLogs:
     """
     Class to retrieve all logs from failed resources.
     No environment version needs to be specified, the latest (highest number) version will be used
+
+    DEPRECATED: Use the diagnose endpoint from the server instead
     """
 
     def __init__(self, client: SyncClient, environment_id: uuid.UUID):
+        LOGGER.warning(f"Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
         self._client = client
         self._environment_id = environment_id
 

--- a/src/pytest_inmanta_lsm/failed_resources_logs.py
+++ b/src/pytest_inmanta_lsm/failed_resources_logs.py
@@ -24,7 +24,7 @@ class FailedResourcesLogs:
     """
 
     def __init__(self, client: SyncClient, environment_id: uuid.UUID):
-        LOGGER.warning(f"Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
+        LOGGER.warning("Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
         self._client = client
         self._environment_id = environment_id
 

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -11,6 +11,8 @@ from pprint import pformat
 from typing import Any, Collection, Dict, List, Optional, Union
 from uuid import UUID
 
+from inmanta_lsm.diagnose.model import FullDiagnosis
+
 from pytest_inmanta_lsm import remote_orchestrator as r_orchestrator
 from pytest_inmanta_lsm.exceptions import VersionExceededError, VersionMismatchError
 from pytest_inmanta_lsm.wait_for_state import State, WaitForState
@@ -348,7 +350,7 @@ class ManagedServiceInstance:
                 return False
             return current_state.version == start_version
 
-        def get_bad_state_error(current_state: State) -> Any:
+        def get_bad_state_error(current_state: State) -> FullDiagnosis:
             result = self.remote_orchestrator.client.lsm_service_log_list(
                 tid=self.remote_orchestrator.environment,
                 service_entity=self.service_entity_name,
@@ -360,7 +362,7 @@ class ManagedServiceInstance:
                 f"{json.dumps(result.result or {}, indent=4)}"
             )
 
-            return result.result
+            return FullDiagnosis(**result.result)
 
         wait_for_obj = WaitForState(
             "Instance lifecycle",

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -362,7 +362,7 @@ class ManagedServiceInstance:
                 f"{json.dumps(result.result or {}, indent=4)}"
             )
 
-            return FullDiagnosis(**result.result)
+            return FullDiagnosis(**result.result["data"])
 
         wait_for_obj = WaitForState(
             "Instance lifecycle",

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -351,7 +351,7 @@ class ManagedServiceInstance:
             return current_state.version == start_version
 
         def get_bad_state_error(current_state: State) -> FullDiagnosis:
-            result = self.remote_orchestrator.client.lsm_service_log_list(
+            result = self.remote_orchestrator.client.lsm_services_diagnose(
                 tid=self.remote_orchestrator.environment,
                 service_entity=self.service_entity_name,
                 service_id=self.instance_id,

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -5,7 +5,7 @@
     :contact: code@inmanta.com
     :license: Inmanta EULA
 """
-
+import json
 import logging
 from pprint import pformat
 from typing import Any, Collection, Dict, List, Optional, Union
@@ -13,7 +13,6 @@ from uuid import UUID
 
 from pytest_inmanta_lsm import remote_orchestrator as r_orchestrator
 from pytest_inmanta_lsm.exceptions import VersionExceededError, VersionMismatchError
-from pytest_inmanta_lsm.failed_resources_logs import FailedResourcesLogs
 from pytest_inmanta_lsm.wait_for_state import State, WaitForState
 
 LOGGER = logging.getLogger(__name__)
@@ -349,22 +348,19 @@ class ManagedServiceInstance:
                 return False
             return current_state.version == start_version
 
-        def get_bad_state_error(current_state) -> Any:
-            validation_failure_msg = self.remote_orchestrator.get_validation_failure_message(
-                service_entity_name=self.service_entity_name,
-                service_instance_id=self.instance_id,
+        def get_bad_state_error(current_state: State) -> Any:
+            result = self.remote_orchestrator.client.lsm_service_log_list(
+                tid=self.remote_orchestrator.environment,
+                service_entity=self.service_entity_name,
+                service_id=self.instance_id,
+                version=current_state.version,
             )
-            if validation_failure_msg:
-                return validation_failure_msg
-
-            LOGGER.info("No validation failure message, getting failed resource logs")
-
-            # No validation failure message, so getting failed resource logs
-            failed_resource_logs = FailedResourcesLogs(
-                self.remote_orchestrator.client,
-                self.remote_orchestrator.environment,
+            assert result.code == 200, (
+                f"Wrong response code while trying to get the service diagnostic, got {result.code} (expected 200):\n"
+                f"{json.dumps(result.result or {}, indent=4)}"
             )
-            return failed_resource_logs.get()
+
+            return result.result
 
         wait_for_obj = WaitForState(
             "Instance lifecycle",

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -373,7 +373,7 @@ class RemoteOrchestrator:
 
         DEPRECATED: Use the diagnose endpoint instead
         """
-        LOGGER.warning(f"Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
+        LOGGER.warning("Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
         client = self.client
         environment = self.environment
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -370,7 +370,10 @@ class RemoteOrchestrator:
     ) -> Optional[str]:
         """
         Get the compiler error for a validation failure for a specific service entity
+
+        DEPRECATED: Use the diagnose endpoint instead
         """
+        LOGGER.warning(f"Usage of FailedResourceLogs is deprecated, use the diagnose endpoint instead")
         client = self.client
         environment = self.environment
 

--- a/src/pytest_inmanta_lsm/wait_for_state.py
+++ b/src/pytest_inmanta_lsm/wait_for_state.py
@@ -59,7 +59,7 @@ class WaitForState(object):
         return current_state.name in bad_states
 
     @staticmethod
-    def default_get_bad_state_error(current_state: str) -> Any:
+    def default_get_bad_state_error(current_state: State) -> Any:
         return None
 
     def __init__(
@@ -69,7 +69,7 @@ class WaitForState(object):
         compare_states_method: Callable[[State, List[str]], bool] = default_compare_states.__func__,
         check_start_state_method: Callable[[State], bool] = default_check_start_state.__func__,
         check_bad_state_method: Callable[[State, Collection[str]], bool] = default_check_bad_state.__func__,
-        get_bad_state_error_method: Callable[[str], Any] = default_get_bad_state_error.__func__,
+        get_bad_state_error_method: Callable[[State], Any] = default_get_bad_state_error.__func__,
     ):
         """
         :param name: to clarify the logging,

--- a/src/pytest_inmanta_lsm/wait_for_state.py
+++ b/src/pytest_inmanta_lsm/wait_for_state.py
@@ -9,7 +9,7 @@
 import logging
 import time
 from pprint import pformat
-from typing import Any, Collection, List, Optional
+from typing import Any, Callable, Collection, List, Optional
 
 from pytest_inmanta_lsm import managed_service_instance as msi
 from pytest_inmanta_lsm.exceptions import BadStateError, TimeoutError
@@ -25,7 +25,7 @@ class State:
     def __str__(self):
         return f"{self.name} (version: {self.version})"
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: "State") -> bool:
         if other is None:
             return False
         if self.name != other.name:
@@ -64,12 +64,12 @@ class WaitForState(object):
 
     def __init__(
         self,
-        name,
-        get_states_method,
-        compare_states_method=default_compare_states.__func__,
-        check_start_state_method=default_check_start_state.__func__,
-        check_bad_state_method=default_check_bad_state.__func__,
-        get_bad_state_error_method=default_get_bad_state_error.__func__,
+        name: str,
+        get_states_method: Callable[[int], List[State]],
+        compare_states_method: Callable[[State, List[str]], bool] = default_compare_states.__func__,
+        check_start_state_method: Callable[[State], bool] = default_check_start_state.__func__,
+        check_bad_state_method: Callable[[State, Collection[str]], bool] = default_check_bad_state.__func__,
+        get_bad_state_error_method: Callable[[str], Any] = default_get_bad_state_error.__func__,
     ):
         """
         :param name: to clarify the logging,
@@ -94,10 +94,10 @@ class WaitForState(object):
         self.__check_bad_state = check_bad_state_method
         self.__get_bad_state_error = get_bad_state_error_method
 
-    def __compose_error_msg_with_bad_state_error(self, error_msg: str, current_state: Any) -> str:
+    def __compose_error_msg_with_bad_state_error(self, error_msg: str, current_state: State) -> str:
         bad_state_error = self.__get_bad_state_error(current_state)
         if bad_state_error:
-            error_msg += f", error: {pformat(bad_state_error)}"
+            error_msg += f", error: {pformat(bad_state_error, indent=4, width=140)}"
 
         return error_msg
 


### PR DESCRIPTION
# Description

Use diagnose endpoint to generate failed validation/deployment reports.  
Deprecated the methods which were previously used for this.

closes #118 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
