### PR TITLE
Issue/fix module v2 installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 1.9.0 (?)
 Changes in this release:
 
-- We now automatically install all V2 modules found in de library path in editable mode on the remote orchestrator
+- We now automatically install all V2 modules found in de library path on the remote orchestrator from source.
 - Fix legacy option usage for `lsm_noclean` and `lsm_ssl` (introduced in 1.6.0).
 
 # v 1.8.0 (2022-07-14)

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -322,8 +322,8 @@ class RemoteOrchestrator:
                 )
                 LOGGER.debug(output)
             except subprocess.CalledProcessError as e:
-                LOGGER.error("Process failed out: " + e.output.decode())
-                LOGGER.error("Process failed err: " + e.stderr.decode())
+                LOGGER.error("Process failed out: " + e.output)
+                LOGGER.error("Process failed err: " + e.stderr)
                 raise
 
         # Server cache create, set variables, so cache can be used

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -21,7 +21,7 @@ import pathlib
 import sys
 from typing import List
 
-from inmanta import env, module
+from inmanta import env, module, moduletool
 
 # The project_path has to be provided in env var
 project_path = pathlib.Path(os.environ["PROJECT_PATH"])
@@ -76,10 +76,29 @@ for dir in (project_path / "libs").iterdir():
     v2_modules.append(mod)
     LOGGER.info(f"Module {mod.name} is v2, we will attempt to install it")
 
+
+class MockBuilder(moduletool.V2ModuleBuilder):
+    """
+    This mock builder allows us to build the v2 modules python package correctly.
+    We can not install them using python as some required files (like setup.cfg)
+    would not be included in the target.
+    """
+
+    def build(self, output_directory: str) -> str:
+        self._ensure_plugins(output_directory)
+        self._move_data_files_into_namespace_package_dir(output_directory)
+        return output_directory
+
+
+# Building modules
+for mod in v2_modules:
+    LOGGER.info(f"Building module {mod.name}")
+    MockBuilder(mod.path).build(mod.path)
+
 # Install all v2 modules in editable mode
 if v2_modules:
     LOGGER.info(f"Installing modules from source: {[mod.name for mod in v2_modules]}")
-    project.virtualenv.install_from_source([env.LocalPackagePath(mod.path, editable=True) for mod in v2_modules])
+    project.virtualenv.install_from_source([env.LocalPackagePath(mod.path) for mod in v2_modules])
 
 # Install all other dependencies
 LOGGER.info("Installing other project dependencies")


### PR DESCRIPTION
# Description

Work around the failed editable install for some module v2.  This is not the ideal behavior, I am not sure whether we should persist this fix to make it more robust, or rather find the root cause of the editable install failure.  

This should probably be discussed newt week.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
