### PR TITLE
re-enable printing of error outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v 1.10.0 (?)
 Changes in this release:
 
+- Re-enable printing of diagnose output on failure states
+
 # v 1.9.1 (2022-09-16)
 Changes in this release:
 

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -351,7 +351,7 @@ class ManagedServiceInstance:
                 return False
             return current_state.version == start_version
 
-        def get_bad_state_error(current_state: State) -> FullDiagnosis:
+        def get_bad_state_error(current_state: State) -> Dict[str, Any]:
             result = self.remote_orchestrator.client.lsm_services_diagnose(
                 tid=self.remote_orchestrator.environment,
                 service_entity=self.service_entity_name,
@@ -363,7 +363,7 @@ class ManagedServiceInstance:
                 f"{json.dumps(result.result or {}, indent=4)}"
             )
 
-            return FullDiagnosis(**result.result["data"])
+            return result.result["data"]
 
         wait_for_obj = WaitForState(
             "Instance lifecycle",

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -351,7 +351,7 @@ class ManagedServiceInstance:
                 return False
             return current_state.version == start_version
 
-        def get_bad_state_error(current_state: State) -> Dict[str, Any]:
+        def get_bad_state_error(current_state: State) -> Dict[str, object]:
             result = self.remote_orchestrator.client.lsm_services_diagnose(
                 tid=self.remote_orchestrator.environment,
                 service_entity=self.service_entity_name,


### PR DESCRIPTION
# Description

re-enable printing of error outputs
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

