### PR TITLE
Allow to install dev version of v2 module's dependencies on remote orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 
 - Add documentation regarding the structure of the test suite.
+- Install dev version of v2 module dependencies on remote orchestrator when install mode allows for it
 
 # v 1.9.1 (2022-09-16)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -104,7 +104,13 @@ if v2_modules:
     if not urls:
         raise Exception("No package repos configured for project")
     # plain Python install so core does not apply project's sources -> we need to configure pip index ourselves
-    with env_vars({"PIP_INDEX_URL": urls[0], "PIP_EXTRA_INDEX_URL": " ".join(urls[1:])}):
+    with env_vars(
+        {
+            "PIP_INDEX_URL": urls[0],
+            "PIP_PRE": "0" if project.install_mode == module.InstallMode.release else "1",
+            "PIP_EXTRA_INDEX_URL": " ".join(urls[1:]),
+        }
+    ):
         LOGGER.info(f"Installing modules from source: {[mod.name for mod in v2_modules]}")
         project.virtualenv.install_from_source([env.LocalPackagePath(mod.path, editable=True) for mod in v2_modules])
 


### PR DESCRIPTION
# Description

Allow to install dev version of v2 module's dependencies on remote orchestrator based on install mode

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
