### PR TITLE
Cleanup fixtures pytest inmanta backports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 inmanta-lsm
-pytest-inmanta
+pytest-inmanta==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 inmanta-lsm
-pytest-inmanta==2.5.0.dev
+pytest-inmanta

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 inmanta-lsm
-pytest-inmanta==2.4.1
+pytest-inmanta==2.5.0.dev

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pytest-inmanta~=2.3",
+        "pytest-inmanta~=2.5.dev",
         "inmanta-lsm",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pytest-inmanta~=2.5.dev",
+        "pytest-inmanta~=2.5",
         "inmanta-lsm",
     ],
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+from typing import Optional
 
 import pkg_resources
 import pytest
@@ -25,12 +26,20 @@ def set_cwd(testdir):
 
 
 @pytest.fixture(scope="function", autouse=True)
+def reset_pytest_inmanta_state():
+    yield
+    pytest_inmanta.plugin.ProjectLoader.reset()
+
+
 def deactive_venv():
     old_os_path = os.environ.get("PATH", "")
     old_prefix = sys.prefix
     old_path = sys.path
     old_meta_path = sys.meta_path.copy()
     old_path_hooks = sys.path_hooks.copy()
+    old_pythonpath = os.environ.get("PYTHONPATH", None)
+    old_os_venv: Optional[str] = os.environ.get("VIRTUAL_ENV", None)
+    old_working_set = pkg_resources.working_set
 
     yield
 
@@ -44,7 +53,20 @@ def deactive_venv():
     sys.path_hooks.extend(old_path_hooks)
     # Clear cache for sys.path_hooks
     sys.path_importer_cache.clear()
-    pkg_resources.working_set = pkg_resources.WorkingSet._build_master()
+    # Restore PYTHONPATH
+    if old_pythonpath is not None:
+        os.environ["PYTHONPATH"] = old_pythonpath
+    elif "PYTHONPATH" in os.environ:
+        del os.environ["PYTHONPATH"]
+    # Restore VIRTUAL_ENV
+    if old_os_venv is not None:
+        os.environ["VIRTUAL_ENV"] = old_os_venv
+    elif "VIRTUAL_ENV" in os.environ:
+        del os.environ["VIRTUAL_ENV"]
     # stay compatible with older versions of core: don't call the function if it doesn't exist
+    if hasattr(env, "mock_process_env"):
+        env.mock_process_env(python_path=sys.executable)
     if hasattr(PluginModuleFinder, "reset"):
         PluginModuleFinder.reset()
+    plugins.PluginMeta.clear()
+    loader.unload_inmanta_plugins()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from typing import Optional
 import pkg_resources
 import pytest
 import pytest_inmanta.plugin
+from inmanta import env, loader, plugins
 from inmanta.loader import PluginModuleFinder
 
 pytest_plugins = ["pytester"]
@@ -53,6 +54,7 @@ def deactive_venv():
     sys.path_hooks.extend(old_path_hooks)
     # Clear cache for sys.path_hooks
     sys.path_importer_cache.clear()
+    pkg_resources.working_set = old_working_set
     # Restore PYTHONPATH
     if old_pythonpath is not None:
         os.environ["PYTHONPATH"] = old_pythonpath

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def reset_pytest_inmanta_state():
     pytest_inmanta.plugin.ProjectLoader.reset()
 
 
+@pytest.fixture(scope="function", autouse=True)
 def deactive_venv():
     old_os_path = os.environ.get("PATH", "")
     old_prefix = sys.prefix


### PR DESCRIPTION
# Description

I noticed that the cleanup fixtures in `pytest-inmanta-lsm` were outdated relative to those of `pytest-inmanta`. Since it builds on top of `pytest-inmanta` I think (not 100% sure) all its fixtures are relevant here as well so I set that straight.

This will require a release of `pytest-inmanta`, which I'll take care of if/once approved.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
