### PR TITLE
Add the ability to analyze further back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.11.0 (?)
 Changes in this release:
+- Make it possible to look back further into the history when reporting on failure
 
 # v 1.10.1 (2023-01-30)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -48,6 +48,7 @@ class ManagedServiceInstance:
         remote_orchestrator: "r_orchestrator.RemoteOrchestrator",
         service_entity_name: str,
         service_id: Optional[UUID] = None,
+        lookback_depth: int = 1,
     ) -> None:
         """
         :param remote_orchestrator: remote_orchestrator to create the service instance  on
@@ -57,6 +58,7 @@ class ManagedServiceInstance:
         self.remote_orchestrator = remote_orchestrator
         self.service_entity_name = service_entity_name
         self._instance_id = service_id
+        self._lookback = lookback_depth
 
     @property
     def instance_id(self) -> UUID:
@@ -357,6 +359,8 @@ class ManagedServiceInstance:
                 service_entity=self.service_entity_name,
                 service_id=self.instance_id,
                 version=current_state.version,
+                rejection_lookbehind=self._lookback - 1,
+                failure_lookbehind=self._lookback,
             )
             assert result.code == 200, (
                 f"Wrong response code while trying to get the service diagnostic, got {result.code} (expected 200):\n"

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -54,6 +54,7 @@ class ManagedServiceInstance:
         :param remote_orchestrator: remote_orchestrator to create the service instance  on
         :param service_entity_name: name of the service entity
         :param service_id: manually choose the id of the service instance
+        :param lookback_depth: the amount of states to search for failures if we detect a bad state
         """
         self.remote_orchestrator = remote_orchestrator
         self.service_entity_name = service_entity_name

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -444,6 +444,9 @@ class RemoteOrchestrator:
         return None
 
     def get_managed_instance(
-        self, service_entity_name: str, service_id: Optional[UUID] = None, lookback: int = 1,
+        self,
+        service_entity_name: str,
+        service_id: Optional[UUID] = None,
+        lookback: int = 1,
     ) -> "managed_service_instance.ManagedServiceInstance":
         return managed_service_instance.ManagedServiceInstance(self, service_entity_name, service_id, lookback_depth=lookback)

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -444,6 +444,6 @@ class RemoteOrchestrator:
         return None
 
     def get_managed_instance(
-        self, service_entity_name: str, service_id: Optional[UUID] = None
+        self, service_entity_name: str, service_id: Optional[UUID] = None, lookback: int = 1,
     ) -> "managed_service_instance.ManagedServiceInstance":
-        return managed_service_instance.ManagedServiceInstance(self, service_entity_name, service_id)
+        return managed_service_instance.ManagedServiceInstance(self, service_entity_name, service_id, lookback_depth=lookback)


### PR DESCRIPTION
# Description

For systemtenant, we originally had the ability to look back deeper, which is very important. 

This add back that feature, 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
