### PR TITLE
Add option to specify project and env names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.12.0 (?)
 Changes in this release:
+- Add option to specify project and environment names
 
 # v 1.11.0 (2023-02-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -102,6 +102,22 @@ inm_lsm_env = StringTestParameter(
     legacy=inm_lsm_env_legacy,
 )
 
+inm_lsm_project_name = StringTestParameter(
+    argument="--lsm-project-name",
+    environment_variable="INMANTA_LSM_PROJECT_NAME",
+    usage="Project name to be used for this environment",
+    default="pytest-inmanta-lsm",
+    group=param_group,
+)
+
+inm_lsm_env_name = StringTestParameter(
+    argument="--lsm-environment-name",
+    environment_variable="INMANTA_LSM_ENVIRONMENT_NAME",
+    usage="Environment name",
+    default="pytest-inmanta-lsm",
+    group=param_group,
+)
+
 
 # This is the legacy noclean and ssl option
 # TODO remove this in next major version bump

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -105,7 +105,7 @@ inm_lsm_env = StringTestParameter(
 inm_lsm_project_name = StringTestParameter(
     argument="--lsm-project-name",
     environment_variable="INMANTA_LSM_PROJECT_NAME",
-    usage="Project name to be used for this environment",
+    usage="Project name to be used for this environment. Used only when new environment is created, otherwise this parameter is ignored",
     default="pytest-inmanta-lsm",
     group=param_group,
 )
@@ -113,7 +113,7 @@ inm_lsm_project_name = StringTestParameter(
 inm_lsm_env_name = StringTestParameter(
     argument="--lsm-environment-name",
     environment_variable="INMANTA_LSM_ENVIRONMENT_NAME",
-    usage="Environment name",
+    usage="Environment name. Used only when new environment is created, otherwise this parameter is ignored",
     default="pytest-inmanta-lsm",
     group=param_group,
 )

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -105,7 +105,10 @@ inm_lsm_env = StringTestParameter(
 inm_lsm_project_name = StringTestParameter(
     argument="--lsm-project-name",
     environment_variable="INMANTA_LSM_PROJECT_NAME",
-    usage="Project name to be used for this environment. Used only when new environment is created, otherwise this parameter is ignored",
+    usage=(
+        "Project name to be used for this environment. "
+        "Used only when new environment is created, otherwise this parameter is ignored."
+    ),
     default="pytest-inmanta-lsm",
     group=param_group,
 )

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -43,9 +43,11 @@ from pytest_inmanta_lsm.parameters import (
     inm_lsm_ctr_license,
     inm_lsm_ctr_pub_key,
     inm_lsm_env,
+    inm_lsm_env_name,
     inm_lsm_host,
     inm_lsm_no_clean,
     inm_lsm_partial_compile,
+    inm_lsm_project_name,
     inm_lsm_srv_port,
     inm_lsm_ssh_port,
     inm_lsm_ssh_user,
@@ -122,6 +124,16 @@ def remote_orchestrator_container(
 @pytest.fixture(scope="session")
 def remote_orchestrator_environment(request: pytest.FixtureRequest) -> str:
     return inm_lsm_env.resolve(request.config)
+
+
+@pytest.fixture(scope="session")
+def remote_orchestrator_environment_name(request: pytest.FixtureRequest) -> str:
+    return inm_lsm_env_name.resolve(request.config)
+
+
+@pytest.fixture(scope="session")
+def remote_orchestrator_project_name(request: pytest.FixtureRequest) -> str:
+    return inm_lsm_project_name.resolve(request.config)
 
 
 @pytest.fixture(scope="session")
@@ -244,6 +256,8 @@ def remote_orchestrator(
     remote_orchestrator_no_clean: bool,
     remote_orchestrator_host: Tuple[str, int],
     remote_orchestrator_partial: bool,
+    remote_orchestrator_project_name: str,
+    remote_orchestrator_environment_name: str,
 ) -> Iterator[RemoteOrchestrator]:
     LOGGER.info("Setting up remote orchestrator")
 
@@ -305,6 +319,8 @@ def remote_orchestrator(
         ca_cert=ca_cert,
         container_env=container_env,
         port=port,
+        project_name=remote_orchestrator_project_name,
+        environment_name=remote_orchestrator_environment_name,
     )
     remote_orchestrator.clean()
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -51,6 +51,8 @@ class RemoteOrchestrator:
         container_env: bool = False,
         *,
         port: int,
+        environment_name: str = "pytest-inmanta-lsm",
+        project_name: str = "pytest-inmanta-lsm",
     ) -> None:
         """
         Utility object to manage a remote orchestrator and integrate with pytest-inmanta
@@ -68,6 +70,8 @@ class RemoteOrchestrator:
         :param ca_cert: Certificate used for authentication
         :param container_env: Whether the remote orchestrator is running in a container, without a systemd init process.
         :param port: The port the server is listening to
+        :param environment_name: Name of the environment in web console
+        :param project_name: Name of the project in web console
         """
         self._env = environment
         self._host = host
@@ -80,6 +84,8 @@ class RemoteOrchestrator:
         self._token = token
         self._ca_cert = ca_cert
         self.container_env = container_env
+        self.environment_name = environment_name
+        self.project_name = project_name
 
         inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self._env))
@@ -173,8 +179,8 @@ class RemoteOrchestrator:
             return result.result["data"]["id"]
 
         result = client.create_environment(
-            project_id=ensure_project("pytest-inmanta-lsm"),
-            name="pytest-inmanta-lsm",
+            project_id=ensure_project(self.project_name),
+            name=self.environment_name,
             environment_id=self._env,
         )
         assert (

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -57,6 +57,9 @@ class RemoteOrchestrator:
         """
         Utility object to manage a remote orchestrator and integrate with pytest-inmanta
 
+        Parameters `environment_name` and `project_name` are used only when new environment is created. If environment with
+        given UUID (`environment`) exists in the orchestrator, these parameters are ignored.
+
         :param host: the host to connect to, the orchestrator should be on port 8888, ssh on port 22
         :param ssh_user: the username to log on to the machine, should have sudo rights
         :param ssh_port: the port to use to log on to the machine


### PR DESCRIPTION
# Description

Feature requested on slack. New cli options are added, allowing to specify environment and project names. Name options are applied only on creation of missing entries (project/env), no modification is done if uuid of environment matches one of the existing environments.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
