### PR TITLE
[FIX] remove unused variable

### DIFF
--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -207,7 +207,6 @@ def remote_orchestrator_project_shared(request: pytest.FixtureRequest, project_s
     # no need to do anything if this version of inmanta does not support v2 modules or if in_place already adds it to the path
     if hasattr(module, "ModuleV2") and not in_place:
         mod: module.Module
-        path: str
         mod, _ = pytest_inmanta.plugin.get_module()
 
         # mod object is constructed from the source dir: it does not contain all installation metadata


### PR DESCRIPTION
# Description

Flake8 upper bound removal caused the following warning to pop up :
```
src/pytest_inmanta_lsm/plugin.py:210:9: F842 local variable 'path' is annotated but never used
```
This removes the unused variable.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
