### PR TITLE
Update LSM project mock to include ServiceEntityBindingV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 1.12.0 (?)
 Changes in this release:
 - Add option to specify project and environment names
+- Extend LsmProject to mock ServiceEntityBindingV2
 
 # v 1.11.0 (2023-02-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -103,6 +103,14 @@ class LsmProject:
             self.lsm_services_list,
             raising=False,
         )
+
+        self.monkeypatch.setattr(
+            inmanta_plugins.lsm.global_cache.get_client(),
+            "lsm_services_update_attributes",
+            self.lsm_services_update_attributes,
+            raising=False,
+        )
+
         self.monkeypatch.setattr(
             inmanta_plugins.lsm.global_cache.get_client(),
             "lsm_services_update_attributes_v2",
@@ -191,7 +199,7 @@ class LsmProject:
     ) -> inmanta.protocol.common.Result:
         """
         This is a mock for the lsm api, this method is called during allocation to update
-        the attributes of a service.
+        the attributes of a V2 service.
         """
         # Making some basic checks
         service = self.services[str(service_id)]

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -18,7 +18,7 @@ import inmanta_lsm.const
 import inmanta_lsm.model
 import pytest
 import pytest_inmanta.plugin
-from inmanta_lsm.dict_path import DictPath
+from inmanta_lsm.dict_path import DictPath, to_path
 
 # Error message to display when the lsm module is not reachable
 INMANTA_LSM_MODULE_NOT_LOADED = (
@@ -219,10 +219,8 @@ class LsmProject:
         # Edit logic derived from:
         # https://github.com/inmanta/inmanta-lsm/blob/39e9319381ce6cfc9fd22549e2b5a9cc7128ded2/src/inmanta_lsm/model.py#L2794
 
-        from inmanta_plugins.lsm.allocation_v2 import dict_path
-
         for current_edit in edit:
-            dict_path_obj: DictPath = dict_path.to_path(current_edit.target)
+            dict_path_obj: DictPath = to_path(current_edit.target)
 
             if current_edit.operation == inmanta_lsm.model.EditOperation.replace.value:
                 dict_path_obj.set_element(service.candidate_attributes, current_edit.value)

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -19,7 +19,6 @@ import inmanta_lsm.model
 import pytest
 import pytest_inmanta.plugin
 from inmanta_lsm.dict_path import DictPath
-from inmanta_plugins.lsm.allocation_v2 import dict_path
 
 # Error message to display when the lsm module is not reachable
 INMANTA_LSM_MODULE_NOT_LOADED = (
@@ -219,6 +218,9 @@ class LsmProject:
 
         # Edit logic derived from:
         # https://github.com/inmanta/inmanta-lsm/blob/39e9319381ce6cfc9fd22549e2b5a9cc7128ded2/src/inmanta_lsm/model.py#L2794
+
+        from inmanta_plugins.lsm.allocation_v2 import dict_path
+
         for current_edit in edit:
             dict_path_obj: DictPath = dict_path.to_path(current_edit.target)
 

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -195,7 +195,7 @@ class LsmProject:
         service_id: uuid.UUID,
         current_version: int,
         patch_id: str,
-        edit: typing.List[inmanta_lsm.model.PatchCallEdit],
+        edit: typing.List["inmanta_lsm.model.PatchCallEdit"],
         comment: typing.Optional[str] = None,
     ) -> inmanta.protocol.common.Result:
         """

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -18,6 +18,8 @@ import inmanta_lsm.const
 import inmanta_lsm.model
 import pytest
 import pytest_inmanta.plugin
+from inmanta_lsm.dict_path import DictPath
+from inmanta_plugins.lsm.allocation_v2 import dict_path
 
 # Error message to display when the lsm module is not reachable
 INMANTA_LSM_MODULE_NOT_LOADED = (
@@ -215,11 +217,16 @@ class LsmProject:
         if service.candidate_attributes is None:
             service.candidate_attributes = copy.deepcopy(service.active_attributes)
 
-        attrs = {}
-        for patch in edit:
-            attrs[patch.target] = patch.value
+        # Edit logic derived from:
+        # https://github.com/inmanta/inmanta-lsm/blob/39e9319381ce6cfc9fd22549e2b5a9cc7128ded2/src/inmanta_lsm/model.py#L2794
+        for current_edit in edit:
+            dict_path_obj: DictPath = dict_path.to_path(current_edit.target)
 
-        service.candidate_attributes.update(attrs)
+            if current_edit.operation == inmanta_lsm.model.EditOperation.replace.value:
+                dict_path_obj.set_element(service.candidate_attributes, current_edit.value)
+            else:
+                assert False, "Only EditOperation.replace is supported in mock mode"
+
         service.last_updated = datetime.datetime.now()
 
         return inmanta.protocol.common.Result(code=200, result={})


### PR DESCRIPTION
# Description

The `lsm_services_update_attributes_v2` was not being mocked resulting in the `test_lsm_mocked` tests on `athonet_mpn` to fail with the update to `ServiceEntityBindingV2`


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
- [ x ] Type annotations are present
- [ x ] Code is clear and sufficiently documented
- [ x ] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ x ] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
