### PR TITLE
Ignore cfcache when syncing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Update caching mechanism, don't keep project venv in between test session.
 - Halt environment after each test run, resume it before each test run.
+- Don't sync local project's cfcache to the remote orchestrator
 
 # v 1.12.0 (2023-04-03)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -351,7 +351,7 @@ class RemoteOrchestrator:
         # All the files to exclude when syncing the project, either because
         # we will sync them separately later, or because their content doesn't
         # have anything to do on the remote orchestrator
-        excludes = [".env", "env"]
+        excludes = [".env", "env", ".cfcache"]
 
         # Exclude modules dirs, as we will sync them separately later
         for modules_dir_path in modules_dir_paths:


### PR DESCRIPTION
# Description

Ignore cfcache when rsync-ing the project to the remote orchestrator.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
