### PR TITLE
Issue/parametrize environment halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v 2.0.0 (?)
 Changes in this release:
 - Update caching mechanism, don't keep project venv in between test session.
-- Halt environment after each test run, resume it before each test run.
+- Halt environment after each test run, resume it before each test run. (this behavior can be overwritten for specific test case by overwriting the `remote_orchestrator_halt_environment` fixture)
 - Don't sync local project's cfcache to the remote orchestrator
 
 # v 1.12.0 (2023-04-03)

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -323,6 +323,10 @@ def remote_orchestrator_project(remote_orchestrator_shared: RemoteOrchestrator, 
 
 @pytest.fixture
 def remote_orchestrator_halt_environment(remote_orchestrator_shared: RemoteOrchestrator) -> Iterator[None]:
+    """
+    Fixture which makes sure the environment on the orchestrator is halted after the test run.  This logic is
+    extracted out of the remote_orchestrator fixture to make it easier to overwrite.
+    """
     yield None
 
     # Stop the environment, to make sure it doesn't continue doing things behind our back

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -168,7 +168,7 @@ def remote_orchestrator_host(
     for _ in range(0, 10):
         try:
             http = "https" if inm_lsm_ssl.resolve(request.config) else "http"
-            response = requests.get(f"{http}://{host}:{port}/api/v1/serverstatus", timeout=1, verify=False)
+            response = requests.get(f"{http}://{host}:{port}/api/v1/serverstatus", timeout=2, verify=False)
             response.raise_for_status()
         except Exception as exc:
             LOGGER.warning(str(exc))
@@ -322,12 +322,22 @@ def remote_orchestrator_project(remote_orchestrator_shared: RemoteOrchestrator, 
 
 
 @pytest.fixture
+def remote_orchestrator_halt_environment(remote_orchestrator_shared: RemoteOrchestrator) -> Iterator[None]:
+    yield None
+
+    # Stop the environment, to make sure it doesn't continue doing things behind our back
+    # This behavior can be change by overwriting this fixture
+    remote_orchestrator_shared.client.halt_environment(remote_orchestrator_shared.environment)
+
+
+@pytest.fixture
 def remote_orchestrator(
     remote_orchestrator_shared: RemoteOrchestrator,
     remote_orchestrator_project: Project,
+    remote_orchestrator_halt_environment: None,
     remote_orchestrator_settings: Dict[str, Union[str, int, bool]],
     remote_orchestrator_partial: bool,
-) -> Iterator[RemoteOrchestrator]:
+) -> RemoteOrchestrator:
     # Attach test project to the remote orchestrator object
     remote_orchestrator_shared.attach_project(remote_orchestrator_project)
 
@@ -355,10 +365,7 @@ def remote_orchestrator(
     # Make sure the environment is running
     remote_orchestrator_shared.client.resume_environment(remote_orchestrator_shared.environment)
 
-    yield remote_orchestrator_shared
-
-    # Stop the environment, to make sure it doesn't continue doing things behind our back
-    remote_orchestrator_shared.client.halt_environment(remote_orchestrator_shared.environment)
+    return remote_orchestrator_shared
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Extract the "halt env after test" out of the `remote_orchestrator` fixture to make it easier to overwrite it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
