### PR TITLE
Issue/minor improvements

### DIFF
--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -429,6 +429,8 @@ class RemoteOrchestrator:
     def clear_environment(self, *, soft: bool = False) -> None:
         """
         Clear the environment, if soft is True, keep all the files of the project.
+
+        :param soft: If true, keeps the project file in place.
         """
         LOGGER.debug("Clear environment")
         project_path = shlex.quote(str(self.remote_project_path))

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -232,10 +232,10 @@ class RemoteOrchestrator:
 
         if shell:
             # The command we received should be run in a shell
-            cmd = shlex.join(["bash", "-c", cmd])
+            cmd = shlex.join(["bash", "-l", "-c", cmd])
 
         # If we need to change user, prefix the command with a sudo
-        if self.ssh_user != user or shell:
+        if self.ssh_user != user:
             # Make sure the user is a safe value to use
             user = shlex.quote(user)
             cmd = f"sudo --login --user={user} -- {cmd}"

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -227,8 +227,7 @@ class RemoteOrchestrator:
         if cwd is not None:
             # Pretend that the command is a shell, and add a cd ... prefix to it
             shell = True
-            cwd_prefix = shlex.join(["cd", cwd]) + "; "
-            cmd = cwd_prefix + cmd
+            cmd = shlex.join(["cd", cwd]) + "; " + cmd
 
         if shell:
             # The command we received should be run in a shell


### PR DESCRIPTION
# Description

Minor improvement for commands executed on the remote orchestrator, we were using `sudo` to get a proper login shell, even if we didn't need to change user, while `bash -l` does exactly what we need.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] ~~Changelog entry~~ No behavior change since last release
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
