### PR TITLE
Issue/212 remove deprecated options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes in this release:
 - Update caching mechanism, don't keep project venv in between test session.
 - Halt environment after the full test suite, resume it before each test run. (the environment can be left running using `--lsm-no-halt` option)
 - Don't sync local project's cfcache to the remote orchestrator
+- Remove deprecated options (#212)
 
 # v 1.12.0 (2023-04-03)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -5,7 +5,6 @@
     :contact: code@inmanta.com
     :license: Inmanta EULA
 """
-import os
 from pathlib import Path
 
 from pytest_inmanta.test_parameter import (
@@ -15,32 +14,14 @@ from pytest_inmanta.test_parameter import (
     StringTestParameter,
 )
 
-try:
-    """
-    Those classes are only used in type annotation, but the import doesn't work
-    in python 3.6.  So we simply catch the error and ignore it.
-    """
-    from pytest import Config
-except ImportError:
-    pass
-
 param_group = "pytest-inmanta-lsm"
-
-# This is the legacy lsm host option
-# TODO (#212) remove this in next major version bump
-inm_lsm_host_legacy = StringTestParameter(
-    argument="--lsm_host",
-    environment_variable="INMANTA_LSM_HOST",
-    usage="Remote orchestrator to use for the remote_inmanta fixture",
-)
 
 inm_lsm_host = StringTestParameter(
     argument="--lsm-host",
-    environment_variable=inm_lsm_host_legacy.environment_variable,
-    usage=inm_lsm_host_legacy.usage,
+    environment_variable="INMANTA_LSM_HOST",
+    usage="Remote orchestrator to use for the remote_inmanta fixture",
     default="127.0.0.1",
     group=param_group,
-    legacy=inm_lsm_host_legacy,
 )
 
 inm_lsm_srv_port = IntegerTestParameter(
@@ -51,55 +32,28 @@ inm_lsm_srv_port = IntegerTestParameter(
     group=param_group,
 )
 
-# This is the legacy lsm user option
-# TODO (#212) remove this in next major version bump
-inm_lsm_user_legacy = StringTestParameter(
-    argument="--lsm_user",
-    environment_variable="INMANTA_LSM_USER",
-    usage="Username to use to ssh to the remote orchestrator",
-)
-
 inm_lsm_ssh_user = StringTestParameter(
     argument="--lsm-ssh-user",
     environment_variable="INMANTA_LSM_SSH_USER",
-    usage=inm_lsm_user_legacy.usage,
+    usage="Username to use to ssh to the remote orchestrator",
     default="centos",
     group=param_group,
-    legacy=inm_lsm_user_legacy,
-)
-
-# This is the legacy lsm port option
-# TODO (#212) remove this in next major version bump
-inm_lsm_port_legacy = IntegerTestParameter(
-    argument="--lsm_port",
-    environment_variable="INMANTA_LSM_PORT",
-    usage="Port to use to ssh to the remote orchestrator",
 )
 
 inm_lsm_ssh_port = IntegerTestParameter(
     argument="--lsm-ssh-port",
     environment_variable="INMANTA_LSM_SSH_PORT",
-    usage=inm_lsm_port_legacy.usage,
+    usage="Port to use to ssh to the remote orchestrator",
     default=22,
     group=param_group,
-    legacy=inm_lsm_port_legacy,
-)
-
-# This is the legacy lsm environment option
-# TODO (#212) remove this in next major version bump
-inm_lsm_env_legacy = StringTestParameter(
-    argument="--lsm_environment",
-    environment_variable="INMANTA_LSM_ENVIRONMENT",
-    usage="The environment to use on the remote server (is created if it doesn't exist)",
 )
 
 inm_lsm_env = StringTestParameter(
     argument="--lsm-environment",
-    environment_variable=inm_lsm_env_legacy.environment_variable,
-    usage=inm_lsm_env_legacy.usage,
+    environment_variable="INMANTA_LSM_ENVIRONMENT",
+    usage="The environment to use on the remote server (is created if it doesn't exist)",
     default="719c7ad5-6657-444b-b536-a27174cb7498",
     group=param_group,
-    legacy=inm_lsm_env_legacy,
 )
 
 inm_lsm_project_name = StringTestParameter(
@@ -121,48 +75,12 @@ inm_lsm_env_name = StringTestParameter(
     group=param_group,
 )
 
-
-# This is the legacy noclean and ssl option
-# TODO remove this in next major version bump
-class _LegacyBooleanTestParameter(BooleanTestParameter):
-    @property
-    def action(self) -> str:
-        """
-        Overwrite the default boolean test parameter action to instead store a string.  This matches
-        the former behavior.
-        """
-        return "store"
-
-    def resolve(self, config: "Config") -> bool:
-        """
-        The legacy option for --lsm_noclean and --lsm_ssl requires some more treatment than the other
-        as the behavior when the option is set is different.  The option is not a simple flag, but
-        accepts a string that should be equal to true.
-
-        This helper function comes to overwrite the resolve method in the legacy option.
-        """
-        option: str = config.getoption(self.argument, default=None) or os.getenv(
-            self.environment_variable,
-            default="",
-        )
-        return option.lower().strip() == "true"
-
-
-# This is the legacy lsm noclean option
-# TODO remove this in next major version bump
-inm_lsm_noclean_legacy = _LegacyBooleanTestParameter(
-    argument="--lsm_noclean",
-    environment_variable="INMANTA_LSM_NOCLEAN",
-    usage="Don't cleanup the orchestrator after tests (for debugging purposes)",
-)
-
 inm_lsm_no_clean = BooleanTestParameter(
     argument="--lsm-no-clean",
     environment_variable="INMANTA_LSM_NO_CLEAN",
-    usage=inm_lsm_noclean_legacy.usage,
+    usage="Don't cleanup the orchestrator after tests (for debugging purposes)",
     default=False,
     group=param_group,
-    legacy=inm_lsm_noclean_legacy,
 )
 
 inm_lsm_no_halt = BooleanTestParameter(
@@ -181,78 +99,40 @@ inm_lsm_partial_compile = BooleanTestParameter(
     group=param_group,
 )
 
-# This is the legacy lsm container env option
-# TODO remove this in next major version bump
-inm_lsm_container_env_legacy = _LegacyBooleanTestParameter(
-    argument="--lsm_container_env",
+inm_lsm_container_env = BooleanTestParameter(
+    argument="--lsm-container-env",
     environment_variable="INMANTA_LSM_CONTAINER_ENV",
     usage=(
         "If set to true, expect the orchestrator to be running in a container without systemd.  "
         "It then assumes that all environment variables required to install the modules are loaded into "
         "each ssh session automatically."
     ),
-)
-
-inm_lsm_container_env = BooleanTestParameter(
-    argument="--lsm-container-env",
-    environment_variable=inm_lsm_container_env_legacy.environment_variable,
-    usage=inm_lsm_container_env_legacy.usage,
     default=False,
     group=param_group,
-    legacy=inm_lsm_container_env_legacy,
-)
-
-# This is the legacy lsm ssl option
-# TODO remove this in next major version bump
-inm_lsm_ssl_legacy = _LegacyBooleanTestParameter(
-    argument="--lsm_ssl",
-    environment_variable="INMANTA_LSM_SSL",
-    usage="[True | False] Choose whether to use SSL/TLS or not when connecting to the remote orchestrator.",
 )
 
 inm_lsm_ssl = BooleanTestParameter(
     argument="--lsm-ssl",
-    environment_variable=inm_lsm_ssl_legacy.environment_variable,
-    usage=inm_lsm_ssl_legacy.usage,
+    environment_variable="INMANTA_LSM_SSL",
+    usage="[True | False] Choose whether to use SSL/TLS or not when connecting to the remote orchestrator.",
     default=False,
     group=param_group,
-    legacy=inm_lsm_ssl_legacy,
-)
-
-# This is the legacy lsm ca cert option
-# TODO remove this in next major version bump
-inm_lsm_ca_cert_legacy = PathTestParameter(
-    argument="--lsm_ca_cert",
-    environment_variable="INMANTA_LSM_CA_CERT",
-    usage="The path to the CA certificate file used to authenticate the remote orchestrator.",
-    exists=True,
-    is_file=True,
 )
 
 inm_lsm_ca_cert = PathTestParameter(
     argument="--lsm-ca-cert",
-    environment_variable=inm_lsm_ca_cert_legacy.environment_variable,
-    usage=inm_lsm_ca_cert_legacy.usage,
+    environment_variable="INMANTA_LSM_CA_CERT",
+    usage="The path to the CA certificate file used to authenticate the remote orchestrator.",
     group=param_group,
     exists=True,
     is_file=True,
-    legacy=inm_lsm_ca_cert_legacy,
-)
-
-# This is the legacy lsm token option
-# TODO remove this in next major version bump
-inm_lsm_token_legacy = StringTestParameter(
-    argument="--lsm_token",
-    environment_variable="INMANTA_LSM_TOKEN",
-    usage="The token used to authenticate to the remote orchestrator when authentication is enabled.",
 )
 
 inm_lsm_token = StringTestParameter(
     argument="--lsm-token",
-    environment_variable=inm_lsm_token_legacy.environment_variable,
-    usage=inm_lsm_token_legacy.usage,
+    environment_variable="INMANTA_LSM_TOKEN",
+    usage="The token used to authenticate to the remote orchestrator when authentication is enabled.",
     group=param_group,
-    legacy=inm_lsm_token_legacy,
 )
 
 inm_lsm_ctr = BooleanTestParameter(


### PR DESCRIPTION
# Description

As we move towards the new major version of pytest-inmanta-lsm, it is (I believe) a good time to remove the deprecated parts of the code.  This PR removes all legacy options.

closes #212 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
