### PR TITLE
Issue/offline openapi gen

### DIFF
--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -114,3 +114,19 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
 
     # Do a second compile, everything should go fine
     lsm_project.compile("import quickstart", service_id=service.id)
+
+
+def test_generate_doc(lsm_project: lsm_project.LsmProject) -> None:
+    lsm_project.project.compile("import quickstart")
+    result = lsm_project.lsm_services_openapi_docs(tid=uuid.UUID(lsm_project.environment))
+    openapi_def = result.result["data"]
+    assert list(openapi_def["paths"].keys()) == [
+        '/lsm/v1/service_inventory/vlan-assignment',
+        '/lsm/v1/service_inventory/vlan-assignment/{service_id}',
+    ]
+    assert list(openapi_def["components"]["schemas"].keys()) == [
+        'vlan-assignment',
+        'DeploymentProgress',
+        'ServiceInstance',
+        'ServiceInstance-vlan-assignment',
+    ]

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -121,12 +121,12 @@ def test_generate_doc(lsm_project: lsm_project.LsmProject) -> None:
     result = lsm_project.lsm_services_openapi_docs(tid=uuid.UUID(lsm_project.environment))
     openapi_def = result.result["data"]
     assert list(openapi_def["paths"].keys()) == [
-        '/lsm/v1/service_inventory/vlan-assignment',
-        '/lsm/v1/service_inventory/vlan-assignment/{service_id}',
+        "/lsm/v1/service_inventory/vlan-assignment",
+        "/lsm/v1/service_inventory/vlan-assignment/{service_id}",
     ]
     assert list(openapi_def["components"]["schemas"].keys()) == [
-        'vlan-assignment',
-        'DeploymentProgress',
-        'ServiceInstance',
-        'ServiceInstance-vlan-assignment',
+        "vlan-assignment",
+        "DeploymentProgress",
+        "ServiceInstance",
+        "ServiceInstance-vlan-assignment",
     ]

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -11,15 +11,15 @@ import typing
 import uuid
 import warnings
 
-import inmanta.server.extensions
 import inmanta.config
-import inmanta.execute.proxy
 import inmanta.const
+import inmanta.execute.proxy
 import inmanta.protocol.common
+import inmanta.server.extensions
 import inmanta.util
 import inmanta_lsm.const
-import inmanta_lsm.openapi
 import inmanta_lsm.model
+import inmanta_lsm.openapi
 import pytest
 import pytest_inmanta.plugin
 
@@ -250,7 +250,7 @@ class LsmProject:
             import inmanta_plugins.lsm  # type: ignore
         except ImportError as e:
             raise RuntimeError(INMANTA_LSM_MODULE_NOT_LOADED) from e
-        
+
         # Making some basic checks
         tid = tid or environment
         assert str(tid) == self.environment, f"{tid} != {self.environment}"
@@ -282,9 +282,7 @@ class LsmProject:
         if format == inmanta.const.ApiDocsFormat.openapi:
             return inmanta.protocol.common.Result(
                 code=200,
-                result={
-                    "data": json.loads(openapi_json_str)
-                },
+                result={"data": json.loads(openapi_json_str)},
             )
 
         raise ValueError(f"Unsupported format: {format}")

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -7,7 +7,7 @@
 """
 
 # Note: These tests only function when the pytest output is not modified by plugins such as pytest-sugar!
-
+import pytest
 import utils
 import versions
 from packaging import version
@@ -34,6 +34,18 @@ def test_basic_example(testdir):
     result = testdir.runpytest("tests/test_quickstart.py")
 
     if versions.INMANTA_CORE_VERSION < version.Version("6"):
-        result.assert_outcomes(passed=2, skipped=1)
+        result.assert_outcomes(passed=3, skipped=1)
     else:
-        result.assert_outcomes(passed=3)
+        result.assert_outcomes(passed=4)
+
+
+def test_docs(testdir: pytest.Testdir):
+    """Make sure that our plugin works."""
+
+    testdir.copy_example("quickstart")
+
+    utils.add_version_constraint_to_project(testdir.tmpdir)
+
+    result = testdir.runpytest("tests/test_quickstart.py::test_generate_doc", "-vvv")
+
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
# Description

Add helper to generate the api documentation of services defined in the model.  
This allow getting them easily, without relying on a server.  Handy to generate some doc from the test cases of a module.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
