### PR TITLE
Fix issue python variables 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 2.0.0 (?)
 Changes in this release:
+- Fix bug about subprocesses started in the docker container that used the local venv of the composer venv and not the global venv.
 - Update caching mechanism, don't keep project venv in between test session.
 - Halt environment after the full test suite, resume it before each test run. (the environment can be left running using `--lsm-no-halt` option)
 - Don't sync local project's cfcache to the remote orchestrator

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -30,7 +30,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     """
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
-    env_vars["PYTHONNOUSERSITE"] = ""
+    env_vars["PYTHONNOUSERSITE"] = "1"
     paths = env_vars["PATH"].split(":")
     new_paths = ":".join([x for x in paths if ".env/bin" not in x])
     env_vars["PATH"] = new_paths

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -27,7 +27,6 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     Helper function to run command and log the results.  Raises a CalledProcessError
     if the command failed.
     """
-
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
         args=cmd,

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -30,7 +30,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     """
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
-    del env_vars["PYTHONPATH"]
+    env_vars.pop("PYTHONPATH", None)
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -31,7 +31,6 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
     del env_vars["PYTHONPATH"]
-    print(f"env_vars-123: {env_vars}")
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -36,7 +36,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
         encoding="utf-8",
         text=True,
         universal_newlines=True,
-        env={"PYTHONNOUSERSITE": 1},
+        env={"PYTHONNOUSERSITE": ""},
     )
     LOGGER.debug(f"Return code: {result.returncode}")
     LOGGER.debug("Stdout: %s", result.stdout)

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -30,10 +30,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     """
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
-    env_vars["PYTHONNOUSERSITE"] = "1"
-    paths = env_vars["PATH"].split(":")
-    new_paths = ":".join([x for x in paths if ".env/bin" not in x])
-    env_vars["PATH"] = new_paths
+    del env_vars["PYTHONPATH"]
     print(f"env_vars-123: {env_vars}")
     result = subprocess.run(
         args=cmd,

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -7,6 +7,7 @@
 """
 import json
 import logging
+import os
 import shutil
 import subprocess
 from configparser import Interpolation
@@ -28,6 +29,8 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     if the command failed.
     """
     LOGGER.info(f"Running command: {cmd}")
+    env_vars = dict(os.environ)
+    env_vars["PYTHONNOUSERSITE"] = ""
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),
@@ -36,7 +39,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
         encoding="utf-8",
         text=True,
         universal_newlines=True,
-        env={"PYTHONNOUSERSITE": ""},
+        env=env_vars,
     )
     LOGGER.debug(f"Return code: {result.returncode}")
     LOGGER.debug("Stdout: %s", result.stdout)

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -31,9 +31,11 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
     env_vars["PYTHONNOUSERSITE"] = ""
-    path = env_vars["PATH"]
-    LOGGER.info(f"path-123: {path}")
-    print(f"path-123: {path}")
+    paths = env_vars["PATH"].split(":")
+    new_paths = ":".join([x for x in paths if ".env/bin" not in x])
+    env_vars["PATH"] = new_paths
+    LOGGER.info(f"env_vars-123: {env_vars}")
+    print(f"env_vars-123: {env_vars}")
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -34,7 +34,6 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     paths = env_vars["PATH"].split(":")
     new_paths = ":".join([x for x in paths if ".env/bin" not in x])
     env_vars["PATH"] = new_paths
-    LOGGER.info(f"env_vars-123: {env_vars}")
     print(f"env_vars-123: {env_vars}")
     result = subprocess.run(
         args=cmd,

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -31,6 +31,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
     env_vars["PYTHONNOUSERSITE"] = ""
+    print(env_vars["PATH"])
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -27,6 +27,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     Helper function to run command and log the results.  Raises a CalledProcessError
     if the command failed.
     """
+
     LOGGER.info(f"Running command: {cmd}")
     result = subprocess.run(
         args=cmd,
@@ -36,6 +37,7 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
         encoding="utf-8",
         text=True,
         universal_newlines=True,
+        env={"PYTHONNOUSERSITE": 1},
     )
     LOGGER.debug(f"Return code: {result.returncode}")
     LOGGER.debug("Stdout: %s", result.stdout)

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -31,7 +31,9 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
     env_vars["PYTHONNOUSERSITE"] = ""
-    print(env_vars["PATH"])
+    path = env_vars["PATH"]
+    LOGGER.info(f"path-123: {path}")
+    print(f"path-123: {path}")
     result = subprocess.run(
         args=cmd,
         cwd=str(cwd),


### PR DESCRIPTION
# Description

fix on previous commit:
This commit makes sure the subprocesses started in the docker container only use the global venv and not the local venv of the composer.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
