### PR TITLE
Issue/pytest inmanta 374 exclude pycache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.1.0 (?)
 Changes in this release:
+- Ignore `__pycache__` dirs when rsyncing the project to the remote orchestrator
 
 # v 3.0.0 (2023-05-17)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -489,7 +489,7 @@ class RemoteOrchestrator:
         # All the files to exclude when syncing the project, either because
         # we will sync them separately later, or because their content doesn't
         # have anything to do on the remote orchestrator
-        excludes = [".env", "env", ".cfcache"]
+        excludes = [".env", "env", ".cfcache", "__pycache__"]
 
         # Exclude modules dirs, as we will sync them separately later
         for modules_dir_path in modules_dir_paths:
@@ -521,7 +521,7 @@ class RemoteOrchestrator:
             self.sync_local_folder(
                 local_folder=pathlib.Path(module._path),  # Use ._path instead of .path to stay backward compatible with iso4
                 remote_folder=libs_path / module.name,
-                excludes=[],
+                excludes=["__pycache__"],
             )
 
             synced_modules.add(module.name)


### PR DESCRIPTION
Extension of inmanta/pytest-inmanta#374 to pytest-inmanta-lsm. I think the reasoning applies here as well and we should ignore the Python cache. Wdyt?