### PR TITLE
Fix issue where pip output is not logged on failure pip command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 3.1.0 (?)
 Changes in this release:
 - Ignore `__pycache__` dirs when rsyncing the project to the remote orchestrator
+- Fix issue where the output of pip is not displayed in the log when the pip command fails.
 
 # v 3.0.0 (2023-05-17)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -325,12 +325,12 @@ class RemoteOrchestrator:
                     f"{self.ssh_user}@{self.host}",
                     cmd,
                 ],
-                stderr=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )
         except subprocess.CalledProcessError as e:
             LOGGER.error("Failed to execute command: %s", cmd)
-            LOGGER.error("Subprocess exited with code %d: %s", e.returncode, str(e.stderr))
+            LOGGER.error("Subprocess exited with code %d: %s", e.returncode, str(e.stdout))
             raise e
 
     def run_command_with_server_env(

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -18,24 +18,14 @@ from inmanta import env, module
 # The project_path has to be provided in env var
 project_path = pathlib.Path(os.environ["PROJECT_PATH"])
 
-LOGGER = logging.getLogger(project_path.name)
-
-try:
-    # Setup logging, this logic is taken from inmanta (non stable api)
-    # https://github.com/inmanta/inmanta-core/blob/47d26e6a441bcbb3766c688c4891505690b2db58/src/inmanta/app.py#L708
-    from inmanta.app import _get_default_stream_handler
-
-    stream_handler = _get_default_stream_handler()
-except Exception as e:
-    stream_handler = logging.StreamHandler(stream=sys.stdout)
-    stream_handler.setLevel(logging.INFO)
-
-    print(str(e))
+stream_handler = logging.StreamHandler(stream=sys.stdout)
+stream_handler.setLevel(logging.DEBUG)
 
 logging.root.handlers = []
 logging.root.addHandler(stream_handler)
 logging.root.setLevel(logging.DEBUG)
 
+LOGGER = logging.getLogger(project_path.name)
 
 @contextlib.contextmanager
 def env_vars(var: abc.Mapping[str, str]) -> abc.Iterator[None]:

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -27,6 +27,7 @@ logging.root.setLevel(logging.DEBUG)
 
 LOGGER = logging.getLogger(project_path.name)
 
+
 @contextlib.contextmanager
 def env_vars(var: abc.Mapping[str, str]) -> abc.Iterator[None]:
     """


### PR DESCRIPTION
# Description

This PR makes sure that the output of `pip` is logged when the command fails. 

closes #326

# Self Check:

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~