### PR TITLE
Set the python_binary version in the .ci-integration-tests files

### DIFF
--- a/.ci-integration-tests-iso4.yml
+++ b/.ci-integration-tests-iso4.yml
@@ -26,3 +26,4 @@ directories_to_lint:
     - examples
     - src
     - tests
+python_binary: python3.6

--- a/.ci-integration-tests-iso5.yml
+++ b/.ci-integration-tests-iso5.yml
@@ -28,3 +28,4 @@ directories_to_lint:
     - examples
     - src
     - tests
+python_binary: python3.9

--- a/.ci-integration-tests-iso6.yml
+++ b/.ci-integration-tests-iso6.yml
@@ -28,3 +28,4 @@ directories_to_lint:
     - examples
     - src
     - tests
+python_binary: python3.9

--- a/.ci-integration-tests-iso7.yml
+++ b/.ci-integration-tests-iso7.yml
@@ -28,3 +28,4 @@ directories_to_lint:
     - examples
     - src
     - tests
+python_binary: python3.11


### PR DESCRIPTION
# Description
Set the python_binary version in the `.ci-integration-tests-iso<x>.yml` files.

Part of #343

# Self Check:

- [x] Attached issue to pull request
- [ ] ~~Changelog entry~~
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
