### PR TITLE
Fix broken testing pipeline pytest-inmanta-lsm-iso4

### DIFF
--- a/.ci-integration-tests-iso4.yml
+++ b/.ci-integration-tests-iso4.yml
@@ -26,4 +26,4 @@ directories_to_lint:
     - examples
     - src
     - tests
-python_binary: python3.6
+python_binary: python3.9


### PR DESCRIPTION
# Description

`pytest-inmanta-lsm` breaks when ran against python3.6. Some of the issues I encountered are:

* The `requirements.dev.txt` contains `inmanta-dev-dependencies==2.82.0` which has a minimal python version of python3.9.
* The `shlex.join()` method is not available on python3.6
* The `shutil.copytree()` method doesn't have a `dirs_exist_ok` argument on python3.6

Give the amount of compatibility issue and the fact this package has been incompatible with python3.6 for some time already without issues, I decided to change to python version back to python3.9 for iso4.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~