### PR TITLE
Issue/check orchestrator reset result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes in this release:
 - Fix issue where the output of pip is not displayed in the log when the pip command fails.
 - Add information to the README on how to configure a Python package repository for V2 modules.
 - Cleanup the settings overview in the README to prevent confusion regarding the name of the environment variable associated with a config option.
+- Assert that all api calls toward the orchestrator which are expected to succeed actually succeeded.
 
 # v 3.0.0 (2023-05-17)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -291,7 +291,7 @@ class ManagedServiceInstance:
         states: Optional[Collection[str]] = None,
         version: Optional[int] = None,
         versions: Optional[Collection[int]] = None,
-        timeout: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT,
         bad_states: Collection[str] = ALL_BAD_STATES,
         start_version: Optional[int] = None,
     ) -> None:
@@ -315,16 +315,6 @@ class ManagedServiceInstance:
         :raises VersionMismatchError: If version(s) is(are) provided and the ending state has a version not in it
         :raises VersionExceededError: If version(s) is(are) provided and the current state goes past it(them)
         """
-        if timeout is None:
-            # Get the current deploy interval from the environment settings
-            environment = self.remote_orchestrator.orchestrator_environment.get_environment(self.remote_orchestrator.client)
-            autostart_agent_deploy_interval: int = environment.settings["autostart_agent_deploy_interval"]
-
-            # Set as default timeout twice the deploy interval, this should help with agent backoff
-            # issues.  The minimum value picked is the DEFAULT_TIMEOUT, which remains unchanged, to
-            # stay backward compatible.
-            timeout = max(ManagedServiceInstance.DEFAULT_TIMEOUT, 2 * autostart_agent_deploy_interval)
-
         desired_states: List[str] = []
         if state is None and states is not None:
             desired_states.extend(states)

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -291,7 +291,7 @@ class ManagedServiceInstance:
         states: Optional[Collection[str]] = None,
         version: Optional[int] = None,
         versions: Optional[Collection[int]] = None,
-        timeout: int = DEFAULT_TIMEOUT,
+        timeout: Optional[int] = None,
         bad_states: Collection[str] = ALL_BAD_STATES,
         start_version: Optional[int] = None,
     ) -> None:
@@ -315,6 +315,18 @@ class ManagedServiceInstance:
         :raises VersionMismatchError: If version(s) is(are) provided and the ending state has a version not in it
         :raises VersionExceededError: If version(s) is(are) provided and the current state goes past it(them)
         """
+        if timeout is None:
+            # Get the current deploy interval from the environment settings
+            environment = self.remote_orchestrator.orchestrator_environment.get_environment(
+                self.remote_orchestrator.client
+            )
+            autostart_agent_deploy_interval: int = environment.settings["autostart_agent_deploy_interval"]
+
+            # Set as default timeout twice the deploy interval, this should help with agent backoff
+            # issues.  The minimum value picked is the DEFAULT_TIMEOUT, which remains unchanged, to
+            # stay backward compatible.
+            timeout = max(ManagedServiceInstance.DEFAULT_TIMEOUT, 2 * autostart_agent_deploy_interval)
+
         desired_states: List[str] = []
         if state is None and states is not None:
             desired_states.extend(states)

--- a/src/pytest_inmanta_lsm/managed_service_instance.py
+++ b/src/pytest_inmanta_lsm/managed_service_instance.py
@@ -317,9 +317,7 @@ class ManagedServiceInstance:
         """
         if timeout is None:
             # Get the current deploy interval from the environment settings
-            environment = self.remote_orchestrator.orchestrator_environment.get_environment(
-                self.remote_orchestrator.client
-            )
+            environment = self.remote_orchestrator.orchestrator_environment.get_environment(self.remote_orchestrator.client)
             autostart_agent_deploy_interval: int = environment.settings["autostart_agent_deploy_interval"]
 
             # Set as default timeout twice the deploy interval, this should help with agent backoff

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -405,8 +405,9 @@ def remote_orchestrator(
 
     # Update the settings on the orchestrator
     for k, v in settings.items():
-        result = remote_orchestrator_shared.client.set_setting(remote_orchestrator_shared.environment, k, v)
-        assert result.code in range(200, 300), str(result.result)
+        # We don't check the result here as some options might not exist is some versions of the
+        # orchestrator.
+        remote_orchestrator_shared.client.set_setting(remote_orchestrator_shared.environment, k, v)
 
     # Make sure the environment is running
     result = remote_orchestrator_shared.client.resume_environment(remote_orchestrator_shared.environment)

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -345,7 +345,8 @@ def remote_orchestrator_shared(
     # If --lsm-no-halt is used, leave the orchestrator running at the end of the
     # test suite.  Otherwise the environment is halted.
     if not remote_orchestrator_no_halt:
-        remote_orchestrator.client.halt_environment(remote_orchestrator.environment)
+        result = remote_orchestrator.client.halt_environment(remote_orchestrator.environment)
+        assert result.code in range(200, 300), str(result.result)
 
 
 @pytest.fixture(scope="session")
@@ -404,10 +405,12 @@ def remote_orchestrator(
 
     # Update the settings on the orchestrator
     for k, v in settings.items():
-        remote_orchestrator_shared.client.set_setting(remote_orchestrator_shared.environment, k, v)
+        result = remote_orchestrator_shared.client.set_setting(remote_orchestrator_shared.environment, k, v)
+        assert result.code in range(200, 300), str(result.result)
 
     # Make sure the environment is running
-    remote_orchestrator_shared.client.resume_environment(remote_orchestrator_shared.environment)
+    result = remote_orchestrator_shared.client.resume_environment(remote_orchestrator_shared.environment)
+    assert result.code in range(200, 300), str(result.result)
 
     return remote_orchestrator_shared
 

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -337,6 +337,9 @@ def remote_orchestrator_shared(
     # Cache the content of the libs folder for later calls to the orchestrator
     remote_orchestrator.cache_libs_folder()
 
+    # Configure the client once more, to make sure we can cleanup everything behind us
+    remote_orchestrator.setup_config()
+
     # If --lsm-no-clean is used, leave the orchestrator as it is, with all its
     # file, otherwise cleanup the project
     if not remote_orchestrator_no_clean:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -389,9 +389,6 @@ def remote_orchestrator(
     # Clean environment, but keep project files
     remote_orchestrator_shared.clear_environment(soft=True)
 
-    # Re-create the environment
-    remote_orchestrator_shared.orchestrator_environment.configure_environment(remote_orchestrator_shared.client)
-
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
         "auto_deploy": True,

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -389,6 +389,9 @@ def remote_orchestrator(
     # Clean environment, but keep project files
     remote_orchestrator_shared.clear_environment(soft=True)
 
+    # Re-create the environment
+    remote_orchestrator_shared.orchestrator_environment.configure_environment(remote_orchestrator_shared.client)
+
     # set the defaults here and lets the fixture override specific values
     settings: Dict[str, Union[bool, str, int]] = {
         "auto_deploy": True,

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -206,8 +206,10 @@ class RemoteOrchestrator:
         self.ca_cert = ca_cert
         self.container_env = container_env
 
+        # Build the client once, it loads the config on every call
+        self.client = inmanta.protocol.endpoints.SyncClient("client")
+
         # Setting up the client when the config is loaded
-        self.client: inmanta.protocol.endpoints.SyncClient
         self.setup_config()
 
         self.orchestrator_environment.configure_environment(self.client)
@@ -254,8 +256,6 @@ class RemoteOrchestrator:
                     inmanta_config.Config.set(section, "ssl_ca_cert_file", self.ca_cert)
             if self.token:
                 inmanta_config.Config.set(section, "token", self.token)
-
-        self.client = inmanta.protocol.endpoints.SyncClient("client")
 
     def _get_server_version(self) -> Version:
         """

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -240,7 +240,6 @@ class RemoteOrchestrator:
     def setup_config(self) -> None:
         """
         Setup the config required to make it possible for the client to reach the orchestrator.
-        The client object is also reconstructed to be sure it load the correct values.
         """
         inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self.environment))

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -581,7 +581,8 @@ class RemoteOrchestrator:
             cache_folder = f"mkdir -p {project_path} && rm -rf {project_cache_path} && mv {project_path} {project_cache_path}"
             self.run_command([cache_folder], shell=True)
 
-        self.client.environment_clear(self.environment)
+        result = self.client.environment_clear(self.environment)
+        assert result.code in range(200, 300), str(result.result)
 
         if soft:
             LOGGER.debug("Restore project from cache")

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -206,8 +206,10 @@ class RemoteOrchestrator:
         self.ca_cert = ca_cert
         self.container_env = container_env
 
+        # Setting up the client when the config is loaded
+        self.client: inmanta.protocol.endpoints.SyncClient
         self.setup_config()
-        self.client = inmanta.protocol.endpoints.SyncClient("client")
+
         self.orchestrator_environment.configure_environment(self.client)
         self.server_version = self._get_server_version()
 
@@ -236,6 +238,7 @@ class RemoteOrchestrator:
     def setup_config(self) -> None:
         """
         Setup the config required to make it possible for the client to reach the orchestrator.
+        The client object is also reconstructed to be sure it load the correct values.
         """
         inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self.environment))
@@ -251,6 +254,8 @@ class RemoteOrchestrator:
                     inmanta_config.Config.set(section, "ssl_ca_cert_file", self.ca_cert)
             if self.token:
                 inmanta_config.Config.set(section, "token", self.token)
+
+        self.client = inmanta.protocol.endpoints.SyncClient("client")
 
     def _get_server_version(self) -> Version:
         """


### PR DESCRIPTION
# Description

Assert that all api calls toward the orchestrator that were until now assumed to work, return an expected return code.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
