### PR TITLE
Fix warning dictpath

### DIFF
--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -27,6 +27,12 @@ INMANTA_LSM_MODULE_NOT_LOADED = (
     "    - If you are using v2 modules: make sure the inmanta-module-lsm is installed in your venv."
 )
 
+# Try to import from inmanta.util.dict_path, if not available pass
+try:
+    from inmanta.util import dict_path
+except ImportError:
+    pass
+
 
 class LsmProject:
     def __init__(
@@ -202,10 +208,6 @@ class LsmProject:
         This is a mock for the lsm api, this method is called during allocation to update
         the attributes of a V2 service.
         """
-        # Import dict_path library of the lsm extension in the function scope, as it might
-        # not be available for older version of the product
-        from inmanta_lsm import dict_path  # type: ignore
-
         # Making some basic checks
         service = self.services[str(service_id)]
         assert str(tid) == self.environment, f"{tid} != {self.environment}"

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -168,7 +168,7 @@ class LsmProject:
         service_entity: str,
         service_id: uuid.UUID,
         current_version: int,
-        attributes: typing.Dict[inmanta_lsm.model.StrictStr, typing.Any],
+        attributes: typing.Dict[str, typing.Any],
     ) -> inmanta.protocol.common.Result:
         """
         This is a mock for the lsm api, this method is called during allocation to update

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -31,7 +31,7 @@ INMANTA_LSM_MODULE_NOT_LOADED = (
 try:
     from inmanta.util import dict_path
 except ImportError:
-    from inmanta_lsm import dict_path  # type: ignore
+    from inmanta_lsm import dict_path
 
 
 class LsmProject:

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -27,11 +27,11 @@ INMANTA_LSM_MODULE_NOT_LOADED = (
     "    - If you are using v2 modules: make sure the inmanta-module-lsm is installed in your venv."
 )
 
-# Try to import from inmanta.util.dict_path, if not available pass
+# Try to import from inmanta.util.dict_path, if not available, fall back to the deprecated inmanta_lsm.dict_path
 try:
     from inmanta.util import dict_path
 except ImportError:
-    pass
+    from inmanta_lsm import dict_path  # type: ignore
 
 
 class LsmProject:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,9 +61,7 @@ def module_v2_venv(module_path: str) -> Iterator[env.VirtualEnv]:
             [
                 venv.python_path,
                 "-m",
-                "inmanta.app",
-                "-X",
-                "module",
+                "pip",
                 "install",
                 "-e",
                 module_path,


### PR DESCRIPTION
# Description

Fix warning dictpath as it should now be imported from inmanta

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
