### PR TITLE
Better logs when docker-compose is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.3.0 (?)
 Changes in this release:
+- Better logs when `docker-compose` in not installed
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -43,8 +43,10 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
             universal_newlines=True,
             env=env_vars,
         )
-    except FileNotFoundError:
-        raise FileNotFoundError("The `docker-compose` command is not found. You need it to have a local orchestrator.")
+    except FileNotFoundError as e:
+        if e.filename == "docker-compose":
+            raise FileNotFoundError("The `docker-compose` command is not found. You need it to have a local orchestrator.")
+        raise e
 
     LOGGER.debug(f"Return code: {result.returncode}")
     LOGGER.debug("Stdout: %s", result.stdout)

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -32,16 +32,20 @@ def run_cmd(*, cmd: List[str], cwd: Path) -> Tuple[str, str]:
     LOGGER.info(f"Running command: {cmd}")
     env_vars = dict(os.environ)
     env_vars.pop("PYTHONPATH", None)
-    result = subprocess.run(
-        args=cmd,
-        cwd=str(cwd),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf-8",
-        text=True,
-        universal_newlines=True,
-        env=env_vars,
-    )
+    try:
+        result = subprocess.run(
+            args=cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            text=True,
+            universal_newlines=True,
+            env=env_vars,
+        )
+    except FileNotFoundError:
+        raise FileNotFoundError("The `docker-compose` command is not found. You need it to have a local orchestrator.")
+
     LOGGER.debug(f"Return code: {result.returncode}")
     LOGGER.debug("Stdout: %s", result.stdout)
     LOGGER.debug("Stderr: %s", result.stderr)
@@ -219,7 +223,6 @@ class OrchestratorContainer:
         # Pull container images
         cmd = ["docker-compose", "--verbose", "pull"]
         run_cmd(cmd=cmd, cwd=self.cwd)
-
         # Starting the lab
         cmd = ["docker-compose", "--verbose", "up", "-d"]
         run_cmd(cmd=cmd, cwd=self.cwd)


### PR DESCRIPTION
# Description

Improve error logs when `docker-compose` is not installed.

closes https://github.com/inmanta/pytest-inmanta-lsm/issues/369

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
