### PR TITLE
Issue/352 add exporter mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 Changes in this release:
 - Better logs when `docker-compose` in not installed
 - Add async RemoteServiceInstance class, for async service testing.
-- Add `export_service_entities` helper to `LsmProject` class.  Allowing to test the definition of a service, and update the attributes of a new service with its default, in the initial validation compile.
+- Add `export_service_entities` helper to `LsmProject` class.  Allowing to test the definition of a service, and update the attributes of a new service with its default, in the initial validation compile.  (#352)
+- Allow to easily reuse model used in `export_service_entities` for all later compiles.
+- Validate that any service added to the `LsmProject` object using `add_service` method is part of one of the exported services. (#354)
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Better logs when `docker-compose` in not installed
 - Add async RemoteServiceInstance class, for async service testing.
+- Add `export_service_entities` helper to `LsmProject` class.  Allowing to test the definition of a service, and update the attributes of a new service with its default, in the initial validation compile.
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/README.md
+++ b/README.md
@@ -202,9 +202,6 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
     # Do a first validation compile, and add all default values to our candidate attributes
     lsm_project.compile(service_id=service.id, validation=True, add_defaults=True)
 
-    # Assert that the default value has been added to our attributes
-    assert "value_with_default" in service.candidate_attributes
-
     # The first validation compile went fine, move to the next state
     pytest_inmanta_lsm.lsm_project.promote(service)
     service.version += 1

--- a/README.md
+++ b/README.md
@@ -193,8 +193,20 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
     # for EACH compile
     lsm_project.add_service(service)
 
-    # Run a compile, with central focus the service we just created
+    # Export the service entities
+    lsm_project.export_service_entities("import quickstart")
+
+    # Do a first validation compile, and add all default values to our candidate attributes
+    lsm_project.compile("import quickstart", service_id=service.id, validation=True, add_defaults=True)
+
+    # The first validation compile went fine, move to the next state
+    pytest_inmanta_lsm.lsm_project.promote(service)
+    service.version += 1
+    service.state = "creating"
+
+    # Do a second compile, in the non-validating creating state
     lsm_project.compile("import quickstart", service_id=service.id)
+
 ```
 
 ## Options and environment variables

--- a/README.md
+++ b/README.md
@@ -196,11 +196,9 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
         service_identity_attribute_value=None,
     )
 
-    # Add a service to our inventory
-    lsm_project.add_service(service)
-
-    # Do a first validation compile, and add all default values to our candidate attributes
-    lsm_project.compile(service_id=service.id, validation=True, add_defaults=True)
+    # Add a service to our inventory, do a first validation compile, and add all
+    # default values to our candidate attributes
+    lsm_project.add_service(service, validate=True)
 
     # The first validation compile went fine, move to the next state
     pytest_inmanta_lsm.lsm_project.promote(service)

--- a/README.md
+++ b/README.md
@@ -169,8 +169,10 @@ This toolbox comes with one more fixture: `lsm_project`.  This fixture allows to
 
 A simple usage would be as follow:
 ```python
-def test_model(lsm_project: lsm_project.LsmProject) -> None:
-    # Create a service object, you can modify it as you wish, depending on what you are trying to test
+def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
+    # Export the service entities
+    lsm_project.export_service_entities("import quickstart")
+
     service = inmanta_lsm.model.ServiceInstance(
         id=uuid.uuid4(),
         environment=lsm_project.environment,
@@ -178,7 +180,12 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
         version=1,
         config={},
         state="start",
-        candidate_attributes={"router_ip": "10.1.9.17", "interface_name": "eth1", "address": "10.0.0.254/24", "vlan_id": 14},
+        candidate_attributes={
+            "router_ip": "10.1.9.17",
+            "interface_name": "eth1",
+            "address": "10.0.0.254/24",
+            "vlan_id": 14,
+        },
         active_attributes=None,
         rollback_attributes=None,
         created_at=datetime.datetime.now(),
@@ -189,15 +196,14 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
         service_identity_attribute_value=None,
     )
 
-    # Add the service to the mocked server.  From now on it will be taken into account
-    # for EACH compile
+    # Add a service to our inventory
     lsm_project.add_service(service)
 
-    # Export the service entities
-    lsm_project.export_service_entities("import quickstart")
-
     # Do a first validation compile, and add all default values to our candidate attributes
-    lsm_project.compile("import quickstart", service_id=service.id, validation=True, add_defaults=True)
+    lsm_project.compile(service_id=service.id, validation=True, add_defaults=True)
+
+    # Assert that the default value has been added to our attributes
+    assert "value_with_default" in service.candidate_attributes
 
     # The first validation compile went fine, move to the next state
     pytest_inmanta_lsm.lsm_project.promote(service)
@@ -205,7 +211,7 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
     service.state = "creating"
 
     # Do a second compile, in the non-validating creating state
-    lsm_project.compile("import quickstart", service_id=service.id)
+    lsm_project.compile(service_id=service.id)
 
 ```
 

--- a/examples/quickstart/model/_init.cf
+++ b/examples/quickstart/model/_init.cf
@@ -24,6 +24,10 @@ entity VlanAssignment extends lsm::ServiceEntity:
     net::vlan_id vlan_id
     string vlan_id__description="The VLAN ID to assign to the given interface."
     lsm::attribute_modifier vlan_id__modifier="rw+"
+
+    string value_with_default = "default"
+    string value_with_default__description = "This value has no use but has a default"
+    lsm::attribute_modifier value_with_default__modifier = "rw+"
 end
 
 index VlanAssignment(router_ip, interface_name, vlan_id)
@@ -54,6 +58,7 @@ for assignment in lsm::all(binding):
         interface_name=assignment["attributes"]["interface_name"],
         address=assignment["attributes"]["address"],
         vlan_id=assignment["attributes"]["vlan_id"],
+        value_with_default=assignment["attributes"]["value_with_default"],
         entity_binding=binding,
     )
 end

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -241,11 +241,9 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
         service_identity_attribute_value=None,
     )
 
-    # Add a service to our inventory
-    lsm_project.add_service(service)
-
-    # Do a first validation compile, and add all default values to our candidate attributes
-    lsm_project.compile(service_id=service.id, validation=True, add_defaults=True)
+    # Add a service to our inventory, do a first validation compile, and add all
+    # default values to our candidate attributes
+    lsm_project.add_service(service, validate=True)
 
     # Assert that the default value has been added to our attributes
     assert "value_with_default" in service.candidate_attributes

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -246,6 +246,9 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
     # Do a first validation compile, and add all default values to our candidate attributes
     lsm_project.compile("import quickstart", service_id=service.id, validation=True, add_defaults=True)
 
+    # Assert that the default value has been added to our attributes
+    assert "value_with_default" in service.candidate_attributes
+
     # The first validation compile went fine, move to the next state
     pytest_inmanta_lsm.lsm_project.promote(service)
     service.version += 1

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -222,7 +222,12 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
         version=1,
         config={},
         state="start",
-        candidate_attributes={"router_ip": "10.1.9.17", "interface_name": "eth1", "address": "10.0.0.254/24", "vlan_id": 14},
+        candidate_attributes={
+            "router_ip": "10.1.9.17",
+            "interface_name": "eth1",
+            "address": "10.0.0.254/24",
+            "vlan_id": 14,
+        },
         active_attributes=None,
         rollback_attributes=None,
         created_at=datetime.datetime.now(),
@@ -235,8 +240,11 @@ def test_model(lsm_project: lsm_project.LsmProject) -> None:
 
     lsm_project.add_service(service)
 
+    # Export the service entities
+    lsm_project.export_service_entities("import quickstart")
+
     # Do a first compile, everything should go fine
-    lsm_project.compile("import quickstart", service_id=service.id)
+    lsm_project.compile("import quickstart", service_id=service.id, validation=True, add_defaults=True)
 
     # Do a second compile, everything should go fine
     lsm_project.compile("import quickstart", service_id=service.id)

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -215,6 +215,9 @@ def test_transient_state(project: plugin.Project, remote_orchestrator: remote_or
 
 
 def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
+    # Export the service entities
+    lsm_project.export_service_entities("import quickstart")
+
     service = inmanta_lsm.model.ServiceInstance(
         id=uuid.uuid4(),
         environment=lsm_project.environment,
@@ -238,13 +241,11 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
         service_identity_attribute_value=None,
     )
 
+    # Add a service to our inventory
     lsm_project.add_service(service)
 
-    # Export the service entities
-    lsm_project.export_service_entities("import quickstart")
-
     # Do a first validation compile, and add all default values to our candidate attributes
-    lsm_project.compile("import quickstart", service_id=service.id, validation=True, add_defaults=True)
+    lsm_project.compile(service_id=service.id, validation=True, add_defaults=True)
 
     # Assert that the default value has been added to our attributes
     assert "value_with_default" in service.candidate_attributes
@@ -255,4 +256,4 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
     service.state = "creating"
 
     # Do a second compile, in the non-validating creating state
-    lsm_project.compile("import quickstart", service_id=service.id)
+    lsm_project.compile(service_id=service.id)

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -36,6 +36,17 @@ except ImportError:
     from inmanta_lsm import dict_path  # type: ignore[no-redef,attr-defined]
 
 
+def promote(service: inmanta_lsm.model.ServiceInstance) -> None:
+    """
+    Helper to perform the promote operation on the attribute sets of a service.
+
+    :param service: The service that should be promoted.
+    """
+    service.rollback_attributes = service.active_attributes
+    service.active_attributes = service.candidate_attributes
+    service.candidate_attributes = None
+
+
 class LsmProject:
     def __init__(
         self,

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -376,13 +376,18 @@ class LsmProject:
         :param model: The model to compile (passed to project.compile)
         :param service_id: The id of the service that should be compiled, the service must have
             been added to the set of services prior to the compile.
-        :param validation_compile: Whether this is a validation compile or not.
+        :param validation: Whether this is a validation compile or not.
+        :param add_defaults: Whether the service attribute should be updated to automatically
+            add all the default values defined in the model, similarly to what the lsm api does.
+            This can only be set to True if the following conditions are met:
+            1.  This is the initial validation compile, all the attributes are set in the candidate set.
+            2.  You have called self.export_service_entities prior to calling this method.
         """
         service = self.services[str(service_id)]
 
         if add_defaults and not validation:
             raise ValueError(
-                "Bad usage, defaults can only be set on the initial validation compile " "but validation is disabled."
+                "Bad usage, defaults can only be set on the initial validation compile but validation is disabled."
             )
 
         if add_defaults:

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -282,7 +282,9 @@ class LsmProject:
         This is a mock for the lsm api, this method is called during export of the
         service entities.
         """
-        assert self.service_entities is not None, "Bad usage!!"
+        assert (
+            self.service_entities is not None
+        ), "The service catalog has not been initialized, please call self.export_service_entities"
         assert str(tid) == self.environment, f"{tid} != {self.environment}"
 
         if service_entity not in self.service_entities:
@@ -309,7 +311,9 @@ class LsmProject:
         This is a mock for the lsm api, this method is called during export of the
         service entities.
         """
-        assert self.service_entities is not None, "Bad usage!!"
+        assert (
+            self.service_entities is not None
+        ), "The service catalog has not been initialized, please call self.export_service_entities"
         assert str(tid) == self.environment, f"{tid} != {self.environment}"
 
         # Don't do any validation, just save the service in the catalog
@@ -327,7 +331,9 @@ class LsmProject:
         This is a mock for the lsm api, this method is called during export of the
         service entities.
         """
-        assert self.service_entities is not None, "Bad usage!!"
+        assert (
+            self.service_entities is not None
+        ), "The service catalog has not been initialized, please call self.export_service_entities"
         assert str(tid) == self.environment, f"{tid} != {self.environment}"
 
         # Just the same as doing a create, we overwrite whatever value was already there
@@ -393,7 +399,7 @@ class LsmProject:
             if service.service_entity not in self.service_entities:
                 raise ValueError(
                     f"Unknown service entity {service.service_entity} for service instance {service.id}.  "
-                    f"Supported services are: {list(self.service_entities.keys())}."
+                    f"Known services are: {list(self.service_entities.keys())}."
                 )
 
         self.services[str(service.id)] = service
@@ -450,19 +456,14 @@ class LsmProject:
         service = self.services[str(service_id)]
 
         if add_defaults:
-
+            # The developer requested to fill in all the defaults in the service
             if not validation:
                 raise ValueError(
                     "Bad usage, defaults can only be set on the initial validation compile but validation is disabled."
                 )
 
-            if self.service_entities is None:
-                raise ValueError(
-                    "Bad usage, defaults can only be applied when the corresponding service entity has been exported."
-                )
-
             # Make sure we have the service entity in our catalog
-            if service.service_entity not in self.service_entities:
+            if self.service_entities is None or service.service_entity not in self.service_entities:
                 raise RuntimeError(
                     f"Can not add defaults value for service {service_id} ({service.service_entity}) "
                     f"because its service entity definition has not been exported yet.  "

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -386,10 +386,20 @@ class LsmProject:
                 False,
             )
 
-    def add_service(self, service: inmanta_lsm.model.ServiceInstance) -> None:
+    def add_service(
+        self,
+        service: inmanta_lsm.model.ServiceInstance,
+        *,
+        validate: bool = False,
+    ) -> None:
         """
         Add a service to the simulated environment, it will be from then one taken into account
         in any compile.
+
+        :param service: The service to add to the service inventory.
+        :param validate: When set to true, also trigger the initial validation compile
+            on this service, and prefill all the defaults.  This requires you to have
+            called self.export_service_entities prior to calling this method.
         """
         if str(service.id) in self.services:
             raise ValueError("There is already a service with that id in this environment")
@@ -403,6 +413,11 @@ class LsmProject:
                 )
 
         self.services[str(service.id)] = service
+
+        if validate:
+            # If validate is set, trigger the initial compile immediately, and fill in all
+            # the default values.
+            self.compile(model=None, service_id=service.id, validation=True, add_defaults=True)
 
     def compile(
         self,


### PR DESCRIPTION
# Description

- Add `export_service_entities` helper method to mocked lsm project
- Add capability to prefill the default values when performing a validation compile with the mocked lsm project
- Allow to easily reuse model used in `export_service_entities` for all later compiles.
- Validate that any service added to the `LsmProject` object using `add_service` method is part of one of the exported services.

Closes #352 and #354

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
