### PR TITLE
Issue/cleanup agent map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes in this release:
     - Determine initial state automatically.
     - Follow the first "auto" state transfers, running the corresponding compiles, and applying the corresponding attribute operations.
 - Extend `LsmProject` mocking capability to allow partial compile selection testing.
+- Reset `autostart_agent_map` environment setting when cleaning up the environment in between tests.
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -429,12 +429,20 @@ def remote_orchestrator(
         "autostart_agent_deploy_interval": 600,
         "autostart_agent_repair_splay_time": 600,
         "autostart_agent_repair_interval": 0,
-        "autostart_agent_map": {
-            "internal": "local:",
-        },
         "lsm_partial_compile": remote_orchestrator_partial,
     }
     settings.update(remote_orchestrator_settings)
+
+    # Get server version and check if the server has the patch which safely allows to reset
+    # the agent map
+    # https://github.com/inmanta/inmanta-core/issues/7448
+    orchestrator_version = version.Version(remote_orchestrator_shared.status.version)
+    good_iso7 = orchestrator_version > version.Version("7.1.0.dev")
+    good_iso6 = version.Version("7.dev") > orchestrator_version > version.Version("6.5.0.dev")
+    if good_iso6 or good_iso7:
+        settings["autostart_agent_map"] = {
+            "internal": "local:",
+        }
 
     # Update the settings on the orchestrator
     for k, v in settings.items():

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -402,6 +402,9 @@ def remote_orchestrator(
         "autostart_agent_deploy_interval": 600,
         "autostart_agent_repair_splay_time": 600,
         "autostart_agent_repair_interval": 0,
+        "autostart_agent_map": {
+            "internal": "local:",
+        },
         "lsm_partial_compile": remote_orchestrator_partial,
     }
     settings.update(remote_orchestrator_settings)

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -429,20 +429,12 @@ def remote_orchestrator(
         "autostart_agent_deploy_interval": 600,
         "autostart_agent_repair_splay_time": 600,
         "autostart_agent_repair_interval": 0,
+        "autostart_agent_map": {
+            "internal": "local:",
+        },
         "lsm_partial_compile": remote_orchestrator_partial,
     }
     settings.update(remote_orchestrator_settings)
-
-    # Get server version and check if the server has the patch which safely allows to reset
-    # the agent map
-    # https://github.com/inmanta/inmanta-core/issues/7448
-    orchestrator_version = version.Version(remote_orchestrator_shared.status.version)
-    good_iso7 = orchestrator_version > version.Version("7.1.0.dev")
-    good_iso6 = version.Version("7.dev") > orchestrator_version > version.Version("6.5.0.dev")
-    if good_iso6 or good_iso7:
-        settings["autostart_agent_map"] = {
-            "internal": "local:",
-        }
 
     # Update the settings on the orchestrator
     for k, v in settings.items():

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import devtools.debug
 import inmanta.data.model
+import inmanta.model
 import inmanta.module
 import inmanta.protocol.endpoints
 import pydantic
@@ -239,6 +240,9 @@ class RemoteOrchestrator:
                 ssh_user,
             ]
 
+        # Cached value of the status of the remote orchestrator
+        self._status: typing.Optional[inmanta.data.model.StatusResponse] = None
+
         # Cached value of the name of the user we have on the remote orchestrator
         self._whoami: typing.Optional[str] = None
 
@@ -340,6 +344,7 @@ class RemoteOrchestrator:
         if self._status is None:
             self._status = asyncio.run(self.request("get_server_status", inmanta.data.model.StatusResponse))
             LOGGER.debug("Status of remote orchestrator is %s", devtools.debug.format(self._status))
+            assert self._status is not None, "Failed to get status from the orchestrator"
         return self._status
 
     def _get_server_version(self) -> Version:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -6,6 +6,7 @@
     :license: Inmanta EULA
 """
 
+import asyncio
 import dataclasses
 import logging
 import pathlib
@@ -16,6 +17,7 @@ import uuid
 from pprint import pformat
 from uuid import UUID
 
+import devtools.debug
 import inmanta.data.model
 import inmanta.module
 import inmanta.protocol.endpoints
@@ -329,18 +331,22 @@ class RemoteOrchestrator:
         else:
             return None
 
+    @property
+    def status(self) -> inmanta.data.model.StatusResponse:
+        """
+        Get the server status, including the version of the different components.  The result is cached, as we don't
+        expect the status to change within the lifecycle of this remote orchestrator object.
+        """
+        if self._status is None:
+            self._status = asyncio.run(self.request("get_server_status", inmanta.data.model.StatusResponse))
+            LOGGER.debug("Status of remote orchestrator is %s", devtools.debug.format(self._status))
+        return self._status
+
     def _get_server_version(self) -> Version:
         """
         Get the version of the remote orchestrator
         """
-        server_status: Result = self.client.get_server_status()
-        if server_status.code != 200:
-            raise Exception(f"Failed to get server status for {self.host}")
-        try:
-            assert server_status.result is not None
-            return Version(server_status.result["data"]["version"])
-        except (KeyError, TypeError):
-            raise Exception(f"Unexpected response for server status API call: {server_status.result}")
+        return Version(self.status.version)
 
     @property
     def remote_user(self) -> str:

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -19,7 +19,6 @@ from uuid import UUID
 
 import devtools.debug
 import inmanta.data.model
-import inmanta.model
 import inmanta.module
 import inmanta.protocol.endpoints
 import pydantic
@@ -240,9 +239,6 @@ class RemoteOrchestrator:
                 ssh_user,
             ]
 
-        # Cached value of the status of the remote orchestrator
-        self._status: typing.Optional[inmanta.data.model.StatusResponse] = None
-
         # Cached value of the name of the user we have on the remote orchestrator
         self._whoami: typing.Optional[str] = None
 
@@ -344,7 +340,6 @@ class RemoteOrchestrator:
         if self._status is None:
             self._status = asyncio.run(self.request("get_server_status", inmanta.data.model.StatusResponse))
             LOGGER.debug("Status of remote orchestrator is %s", devtools.debug.format(self._status))
-            assert self._status is not None, "Failed to get status from the orchestrator"
         return self._status
 
     def _get_server_version(self) -> Version:


### PR DESCRIPTION
# Description

Since https://github.com/inmanta/inmanta-core/pull/7449, the agent will be started when they are added to the agent map.  This issue has gone unnoticed for so long because this setting of the environment was not reset in between tests.  This PR fixes it.

This will probably require a few labs to be rebuilt.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
