### PR TITLE
Relax partial compile validation to allow owned-service validation

### DIFF
--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -9,6 +9,7 @@ import copy
 import datetime
 import functools
 import hashlib
+import itertools
 import json
 import logging
 import pathlib
@@ -938,12 +939,14 @@ class LsmProject:
         resource_sets = get_resource_sets(self.project)
         if not service.deleted:
             # Check that the only resource set emitted is the one of this service
-            assert resource_sets.keys() == {str(service_id)}
-            _, owned_resources = resource_sets.popitem()
+            assert str(service_id) in resource_sets.keys()
         else:
             # Check that no resource set is emitted
-            assert resource_sets.keys() == set()
-            owned_resources = []
+            assert str(service_id) not in resource_sets.keys()
+
+        # Get all the owned resources, also the ones from other services we
+        # pulled down in our partial selection
+        owned_resources = list(itertools.chain(*resource_sets.values()))
 
         # Check that each resource that is emitted belongs to the expected resource set
         for resource_id in self.project.resources.keys():


### PR DESCRIPTION
# Description

The post partial validation logic assumed there would be only one resource set in each partial compile.  This was wrong because:
1. A service can pull other services with it in the partial compile selection logic
2. A service can emit more than one resource set

This PR relaxes a bit the constraint that was set, and checks that the resource set of the service is in present, then gather all the owned resources (from all resource sets).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
