### PR TITLE
Issue/local container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes in this release:
     - Determine initial state automatically.
     - Follow the first "auto" state transfers, running the corresponding compiles, and applying the corresponding attribute operations.
 - Extend `LsmProject` mocking capability to allow partial compile selection testing.
+- Add `--lsm-rsh` and `--lsm-rh` to support remote access to a local container without ssh.
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ flake8 = flake8 src tests examples *.py
 .PHONY: install
 install:
 	pip install -U setuptools pip
-	pip install -U -r requirements.dev.txt
-	pip install -U -c requirements.txt . 
+	pip install -U --upgrade-strategy=eager -r requirements.dev.txt -c requirements.txt -e .
 
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -277,9 +277,11 @@ pytest-inmanta-lsm:
                         The environment to use on the remote server (is created
                         if it doesn't exist) (overrides INMANTA_LSM_ENVIRONMENT,
                         defaults to 719c7ad5-6657-444b-b536-a27174cb7498)
-  --lsm-host=LSM_HOST   Remote orchestrator to use for the remote_inmanta
-                        fixture (overrides INMANTA_LSM_HOST, defaults to
-                        127.0.0.1)
+  --lsm-host=LSM_HOST   IP address or domain name of the remote orchestrator api we
+                        wish to use in our test. It will be picked up and used by the
+                        remote_orchestrator fixture.  This is also the default remote
+                        hostname, if it is not specified in the --lsm-rh option.
+                        (overrides INMANTA_LSM_HOST, defaults to 127.0.0.1)
   --lsm-no-clean        Don't cleanup the orchestrator after tests (for
                         debugging purposes) (overrides INMANTA_LSM_NO_CLEAN,
                         defaults to False)
@@ -292,8 +294,11 @@ pytest-inmanta-lsm:
                         command, we will append the host name and `sh` to this value,
                         and pass the command to execute as input to the open remote
                         shell. (overrides INMANTA_LSM_REMOTE_SHELL)
-  --lsm-rh=LSM_RH       The name of the host that we should try to open the remote shell
-                        on. (overrides INMANTA_LSM_REMOTE_HOST)
+  --lsm-rh=LSM_RH       The name of the host that we should try to open the remote
+                        shell on, as recognized by the remote shell command.  This
+                        doesn't have to strictly be a hostname, as long as it is a
+                        valid host identifier to the chosen rsh protocol. (overrides
+                        INMANTA_LSM_REMOTE_HOST)
   --lsm-ssh-port
                         Port to use to ssh to the remote orchestrator (overrides
                         INMANTA_LSM_SSH_PORT, defaults to 22)

--- a/README.md
+++ b/README.md
@@ -286,10 +286,14 @@ pytest-inmanta-lsm:
   --lsm-srv-port
                         Port the orchestrator api is listening to (overrides
                         INMANTA_LSM_SRV_PORT, defaults to 8888)
-  --lsm-rsh=LSM_RSH     A command opening a remote shell on the orchestrator. (overrides
-                        INMANTA_LSM_REMOTE_SHELL)
-  --lsm-rh=LSM_RH       The name of the host that we should try to open the remote shell on.
-                        (overrides INMANTA_LSM_REMOTE_HOST)
+  --lsm-rsh=LSM_RSH     A command which allows us to start a shell on the remote
+                        orchestrator or send file to it.  When sending files, this value
+                        will be passed to the `-e` argument of rsync.  When running a
+                        command, we will append the host name and `sh` to this value,
+                        and pass the command to execute as input to the open remote
+                        shell. (overrides INMANTA_LSM_REMOTE_SHELL)
+  --lsm-rh=LSM_RH       The name of the host that we should try to open the remote shell
+                        on. (overrides INMANTA_LSM_REMOTE_HOST)
   --lsm-ssh-port
                         Port to use to ssh to the remote orchestrator (overrides
                         INMANTA_LSM_SSH_PORT, defaults to 22)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ pytest-inmanta-lsm:
   --lsm-srv-port
                         Port the orchestrator api is listening to (overrides
                         INMANTA_LSM_SRV_PORT, defaults to 8888)
+  --lsm-rsh=LSM_RSH     A command opening a remote shell on the orchestrator. (overrides
+                        INMANTA_LSM_REMOTE_SHELL)
+  --lsm-rh=LSM_RH       The name of the host that we should try to open the remote shell on.
+                        (overrides INMANTA_LSM_REMOTE_HOST)
   --lsm-ssh-port
                         Port to use to ssh to the remote orchestrator (overrides
                         INMANTA_LSM_SSH_PORT, defaults to 22)

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -33,6 +33,20 @@ inm_lsm_srv_port = IntegerTestParameter(
     group=param_group,
 )
 
+inm_lsm_remote_shell = StringTestParameter(
+    argument="--lsm-rsh",
+    environment_variable="INMANTA_LSM_REMOTE_SHELL",
+    usage="A command opening a remote shell on the orchestrator.",
+    group=param_group,
+)
+
+inm_lsm_remote_host = StringTestParameter(
+    argument="--lsm-rh",
+    environment_variable="INMANTA_LSM_REMOTE_HOST",
+    usage="The name of the host that we should try to open the remote shell on.",
+    group=param_group,
+)
+
 inm_lsm_ssh_user = StringTestParameter(
     argument="--lsm-ssh-user",
     environment_variable="INMANTA_LSM_SSH_USER",

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -36,7 +36,11 @@ inm_lsm_srv_port = IntegerTestParameter(
 inm_lsm_remote_shell = StringTestParameter(
     argument="--lsm-rsh",
     environment_variable="INMANTA_LSM_REMOTE_SHELL",
-    usage="A command opening a remote shell on the orchestrator.",
+    usage=(
+        "A command which allows us to start a shell on the remote orchestrator or send file to it.  "
+        "When sending files, this value will be passed to the `-e` argument of rsync.  When running a command, we will "
+        "append the host name and `sh` to this value, and pass the command to execute as input to the open remote shell."
+    ),
     group=param_group,
 )
 

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -20,7 +20,11 @@ param_group = "pytest-inmanta-lsm"
 inm_lsm_host = StringTestParameter(
     argument="--lsm-host",
     environment_variable="INMANTA_LSM_HOST",
-    usage="Remote orchestrator to use for the remote_inmanta fixture",
+    usage=(
+        "IP address or domain name of the remote orchestrator api we wish to use in our test. It "
+        "will be picked up and used by the remote_orchestrator fixture.  This is also the default "
+        "remote hostname, if it is not specified in the --lsm-rh option."
+    ),
     default="127.0.0.1",
     group=param_group,
 )
@@ -47,7 +51,11 @@ inm_lsm_remote_shell = StringTestParameter(
 inm_lsm_remote_host = StringTestParameter(
     argument="--lsm-rh",
     environment_variable="INMANTA_LSM_REMOTE_HOST",
-    usage="The name of the host that we should try to open the remote shell on.",
+    usage=(
+        "The name of the host that we should try to open the remote shell on, "
+        "as recognized by the remote shell command.  This doesn't have to strictly be "
+        "a hostname, as long as it is a valid host identifier to the chosen rsh protocol."
+    ),
     group=param_group,
 )
 

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -300,7 +300,7 @@ def remote_orchestrator_shared(
         ssh_port = None
         container_env = True
         remote_shell = "docker exec -w /var/lib/inmanta -u inmanta -i"
-        remote_host = remote_orchestrator_container.orchestrator["name"]
+        remote_host = remote_orchestrator_container.orchestrator["Name"]
 
     ssl = inm_lsm_ssl.resolve(request.config)
     ca_cert: Optional[str] = None

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -23,7 +23,11 @@ import requests
 from inmanta import module
 from packaging import version
 from pytest_inmanta.plugin import Project
-from pytest_inmanta.test_parameter import ParameterNotSetException, StringTestParameter
+from pytest_inmanta.test_parameter import (
+    ParameterNotSetException,
+    ParameterType,
+    TestParameter,
+)
 
 from pytest_inmanta_lsm import lsm_project
 from pytest_inmanta_lsm.orchestrator_container import (
@@ -279,7 +283,7 @@ def remote_orchestrator_shared(
 
     host, port = remote_orchestrator_host
 
-    def get_optional_option(option: StringTestParameter) -> Optional[str]:
+    def get_optional_option(option: TestParameter[ParameterType]) -> Optional[ParameterType]:
         try:
             return option.resolve(request.config)
         except ParameterNotSetException:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -8,6 +8,7 @@
 
 import logging
 import os
+import shlex
 import shutil
 import textwrap
 import time
@@ -48,6 +49,8 @@ from pytest_inmanta_lsm.parameters import (
     inm_lsm_no_halt,
     inm_lsm_partial_compile,
     inm_lsm_project_name,
+    inm_lsm_remote_host,
+    inm_lsm_remote_shell,
     inm_lsm_srv_port,
     inm_lsm_ssh_port,
     inm_lsm_ssh_user,
@@ -276,18 +279,28 @@ def remote_orchestrator_shared(
 
     host, port = remote_orchestrator_host
 
+    def get_optional_option(option: StringTestParameter) -> Optional[str]:
+        try:
+            return option.resolve(request.config)
+        except ParameterNotSetException:
+            return None
+
     if remote_orchestrator_container is None:
-        ssh_user = inm_lsm_ssh_user.resolve(request.config)
-        ssh_port = inm_lsm_ssh_port.resolve(request.config)
         container_env = inm_lsm_container_env.resolve(request.config)
+        remote_shell = get_optional_option(inm_lsm_remote_shell)
+        remote_host = get_optional_option(inm_lsm_remote_host)
+        ssh_user = get_optional_option(inm_lsm_ssh_user) if remote_shell is None else None
+        ssh_port = get_optional_option(inm_lsm_ssh_port) if remote_shell is None else None
     else:
         # If the orchestrator is running in a container we deployed ourself, we overwrite
         # a few configuration parameters with what matches the deployed orchestrator
         # If the container image behaves differently than assume, those value won't work,
         # no mechanism exists currently to work around this.
-        ssh_user = "inmanta"
-        ssh_port = 22
+        ssh_user = None
+        ssh_port = None
         container_env = True
+        remote_shell = "docker exec -w /var/lib/inmanta -u inmanta -i"
+        remote_host = remote_orchestrator_container.orchestrator["name"]
 
     ssl = inm_lsm_ssl.resolve(request.config)
     ca_cert: Optional[str] = None
@@ -298,12 +311,6 @@ def remote_orchestrator_shared(
             and remote_orchestrator_container.compose_file == inm_lsm_ctr_compose.default
         ):
             LOGGER.warning("SSL currently doesn't work with the default docker-compose file.")
-
-    def get_optional_option(option: StringTestParameter) -> Optional[str]:
-        try:
-            return option.resolve(request.config)
-        except ParameterNotSetException:
-            return None
 
     token = get_optional_option(inm_lsm_token)
     environment_name = get_optional_option(inm_lsm_env_name)
@@ -323,6 +330,8 @@ def remote_orchestrator_shared(
         token=token,
         ca_cert=ca_cert,
         container_env=container_env,
+        remote_shell=shlex.split(remote_shell) if remote_shell is not None else None,
+        remote_host=remote_host,
     )
 
     # Make sure we start our test suite with a clean environment

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -300,7 +300,7 @@ def remote_orchestrator_shared(
         ssh_port = None
         container_env = True
         remote_shell = "docker exec -w /var/lib/inmanta -u inmanta -i"
-        remote_host = remote_orchestrator_container.orchestrator["Name"]
+        remote_host = remote_orchestrator_container.orchestrator["Config"]["Hostname"]
 
     ssl = inm_lsm_ssl.resolve(request.config)
     ca_cert: Optional[str] = None

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -228,7 +228,8 @@ class RemoteOrchestrator:
                 *SSH_CMD,
                 "-p",
                 str(ssh_port),
-                f"{ssh_user}@{self.host}",
+                "-o",
+                f"User={ssh_user}",
             ]
 
         # Allow to change the remote host, as the access to the remote shell or to the

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -201,7 +201,11 @@ class RemoteOrchestrator:
         :param ssl: Option to indicate whether SSL should be used or not. Defaults to false
         :param ca_cert: Certificate used for authentication
         :param container_env: Whether the remote orchestrator is running in a container, without a systemd init process.
-        :param remote_shell: A command which allows us to start a shell on the remote orchestrator.
+        :param remote_shell: A command which allows us to start a shell on the remote orchestrator or send file to it.
+            When sending files, this value will be passed to the `-e` argument of rsync.  When running a command, we will
+            append the host name and `sh` to this value, and pass the command to execute as input to the open remote shell.
+        :param remote_host: The name of the remote host we can execute command on or send files to.  Defaults
+            to the value of the host parameter.
         """
         self.orchestrator_environment = orchestrator_environment
         self.environment = self.orchestrator_environment.id

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -382,12 +382,13 @@ class RemoteOrchestrator:
         if self.ssh_user is not None and self.ssh_user != user:
             # Make sure the user is a safe value to use
             user = shlex.quote(user)
-            cmd = f"sudo --login --user={user} -- {cmd}"
+            cmd = shlex.join(["sudo", "--login", f"--user={user}", "--", *shlex.split(cmd)])
 
+        full_cmd = [*self.remote_shell, self.remote_host, *shlex.split(cmd)]
         LOGGER.debug("Running command on remote orchestrator: %s", cmd)
         try:
             return subprocess.check_output(
-                self.remote_shell + [self.remote_host, *shlex.split(cmd)],
+                full_cmd,
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -471,7 +471,7 @@ class RemoteOrchestrator:
             # The command we received should be run in a shell
             cmd = shlex.join(["bash", "-l", "-c", cmd])
 
-        return self.run_command(args=[base_cmd + " " + cmd], shell=True, user=self.ssh_user)
+        return self.run_command(args=[base_cmd + " " + cmd], shell=True, user=self.ssh_user or "inmanta")
 
     def sync_local_folder(
         self,

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -186,7 +186,7 @@ class RemoteOrchestrator:
         ssl: bool = False,
         ca_cert: typing.Optional[str] = None,
         container_env: bool = False,
-        remote_shell: typing.Optional[list[str]] = None,
+        remote_shell: typing.Optional[typing.Sequence[str]] = None,
         remote_host: typing.Optional[str] = None,
     ) -> None:
         """
@@ -219,11 +219,12 @@ class RemoteOrchestrator:
         self.ca_cert = ca_cert
         self.container_env = container_env
 
+        self.remote_shell: typing.Sequence[str]
         if remote_shell is not None:
             # We got a remote shell command, allowing us to access the remote orchestrator
             self.remote_shell = remote_shell
         elif ssh_user is None or ssh_port is None:
-            # No remote shell command and not ssh user and port, we have no
+            # No remote shell command and no ssh user and port, we have no
             # way of accessing the remote orchestrator
             raise ValueError("Either the remote shell or the ssh access should be provided")
         else:


### PR DESCRIPTION
# Description

Allow to use a local container as remote orchestrator, without needing an ssh daemon inside the container.

The option is not tested in a separate test case but it is covered by the test suite as it is now used in automated deployment of containerized orchestrators (which we do test already) with the `--lsm-ctr` option.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
