### PR TITLE
Issue/facilitate demo setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes in this release:
     - Follow the first "auto" state transfers, running the corresponding compiles, and applying the corresponding attribute operations.
 - Extend `LsmProject` mocking capability to allow partial compile selection testing.
 - Add `--lsm-rsh` and `--lsm-rh` to support remote access to a local container without ssh.
+- Add `remote_orchestrator_access` fixture, which sets up a remote orchestrator object allowing us to interact with the remote environment, but doesn't do any cleanup on its own.
 
 # v 3.2.0 (2024-02-20)
 Changes in this release:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,37 @@ def test_model(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
 
 ```
 
+### Third case: development on an active environment.
+
+In some cases, (i.e. PoC) you might want to update the code of your module that is currently deployed in an environment.
+You can either start a new test case with pytest-inmanta-lsm's `remote_orchestrator` fixture, which will clear up everything
+and allow you to start from scratch.  Or you can use the similar `remote_orchestrator_access` fixture, which gives you the
+same handy `RemoteOrchestrator` object, but doesn't clear the environment of any existing services, or resources.  This allows
+you for example to re-export the service catalog, or re-synchronize your module's source code and keep all the existing services.
+
+To do so, simply create a test case using the `remote_orchestrator_access` fixture, and the same cli/env var options as used for
+normal pytest-inmanta-lsm test cases.
+```python
+def test_update_existing_environment(
+    project: plugin.Project,
+    remote_orchestrator_access: remote_orchestrator.RemoteOrchestrator,
+) -> None:
+    """
+    Make sure that it is possible to simply run a compile and export service entities,
+    without initially cleaning up the environment.
+    """
+
+    # Setup the compiler config
+    remote_orchestrator_access.setup_config()
+
+    # Do a local compile of our model
+    project.compile("import quickstart")
+
+    # Export service entities (and update the project)
+    remote_orchestrator_access.export_service_entities()
+
+```
+
 ## Options and environment variables
 
 The following options are available, each with a corresponding environment variable.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pytest-inmanta-lsm
 
+[![pypi version](https://img.shields.io/pypi/v/pytest-inmanta-lsm.svg)](https://pypi.python.org/pypi/pytest-inmanta-lsm/)
+
 A pytest plugin to test inmanta modules that use lsm, it is built on top of `pytest-inmanta` and `pytest-inmanta-extensions`
 
 ## Installation

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -323,3 +323,22 @@ def test_partial_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject)
     service.version += 1
     lsm_project.compile(service_id=service.id)
     lsm_project.post_partial_compile_validation(service.id, shared_resources, owned_resources)
+
+
+def test_update_existing_environment(
+    project: plugin.Project,
+    remote_orchestrator_access: remote_orchestrator.RemoteOrchestrator,
+) -> None:
+    """
+    Make sure that it is possible to simply run a compile and export service entities,
+    without initially cleaning up the environment.
+    """
+
+    # Setup the compiler config
+    remote_orchestrator_access.setup_config()
+
+    # Do a local compile of our model
+    project.compile("import quickstart")
+
+    # Export service entities (and update the project)
+    remote_orchestrator_access.export_service_entities()

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -721,8 +721,11 @@ class LsmProject:
             next_state(transfer.target)
         except Exception:
             perform_attribute_operation(service, transfer.error_operation)
-            next_state(transfer.error)
+            if transfer.error is not None:
+                next_state(transfer.error)
             raise
+
+        return service
 
     def create_service(
         self,
@@ -756,7 +759,7 @@ class LsmProject:
             version=1,
             config={},
             state=service_entity.lifecycle.initial_state,
-            candidate_attributes=service_entity.add_defaults(attributes),
+            candidate_attributes=service_entity.add_defaults(attributes),  # type: ignore
             active_attributes=None,
             rollback_attributes=None,
             created_at=datetime.datetime.now(),
@@ -817,7 +820,7 @@ class LsmProject:
             raise RuntimeError(f"Service {service.id} can not be updated from state {service.state}")
 
         # Update the candidate attributes and apply all the defaults to them
-        service.candidate_attributes = service_entity.add_defaults(attributes)
+        service.candidate_attributes = service_entity.add_defaults(attributes)  # type: ignore
         service.last_updated = datetime.datetime.now()
 
         if not auto_transfer:

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -30,4 +30,4 @@ def test_basic_example(testdir):
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
     result = testdir.runpytest("tests/test_quickstart.py")
-    result.assert_outcomes(passed=4)
+    result.assert_outcomes(passed=5)

--- a/tests/test_containerized_orchestrator.py
+++ b/tests/test_containerized_orchestrator.py
@@ -79,4 +79,4 @@ def test_basic_example(testdir: Testdir):
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
     result = testdir.runpytest("tests/test_quickstart.py", "--lsm-ctr")
-    result.assert_outcomes(passed=4)
+    result.assert_outcomes(passed=5)


### PR DESCRIPTION
# Description

For PoC, we very often don't have a project to clone in the orchestrator environment, we only work with a module, and pytest-inmanta-lsm test cases.  It can be frustrating to clear the environment everytime we want to update the module's code, or service definition.

This MR adds a new fixture, which returns the remote orchestrator object and all its nice features, without the initial cleanup the `remote_orchestrator` fixture does.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
