### PR TITLE
Add the ability to generate a base load similar to the Inmanta dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 3.4.0 (?)
 Changes in this release:
 - Add support to `LsmProject.compile` to have multiple instances selected
+- Add `LoadGenerator` helper to generate some load on the remote orchestrator
 
 # v 3.3.0 (2024-04-15)
 Changes in this release:

--- a/examples/quickstart/model/_init.cf
+++ b/examples/quickstart/model/_init.cf
@@ -8,7 +8,10 @@
 
 import lsm
 import lsm::fsm
-import net
+typedef vlan_id as int matching std::validate_type("pydantic.conint", self, {"ge": 0, "lt": 4096})
+"""
+    A constrained integer that represents a vlan identifier
+"""
 
 entity VlanAssignment extends lsm::ServiceEntity:
     std::ipv_any_address router_ip
@@ -21,7 +24,7 @@ entity VlanAssignment extends lsm::ServiceEntity:
     string address__description="The IP-address/netmask to assign to the given VLAN interface."
     lsm::attribute_modifier address__modifier="rw+"
 
-    net::vlan_id vlan_id
+    vlan_id vlan_id
     string vlan_id__description="The VLAN ID to assign to the given interface."
     lsm::attribute_modifier vlan_id__modifier="rw+"
 

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import copy
+import time
 import uuid
 
 import inmanta_lsm.model
@@ -16,6 +17,7 @@ from pytest_inmanta import plugin
 
 import pytest_inmanta_lsm.lsm_project
 from pytest_inmanta_lsm import (
+    load_generator,
     remote_orchestrator,
     remote_service_instance,
     remote_service_instance_async,
@@ -169,6 +171,41 @@ def test_full_cycle(project: plugin.Project, remote_orchestrator: remote_orchest
 
     # Run all the services
     util.sync_execute_scenarios(first_service, duplicated_service, another_service, timeout=60)
+
+
+def test_full_cycle_with_load_generator(
+    caplog: pytest.LogCaptureFixture, project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator
+) -> None:
+    service_type = "vlan-assignment"
+
+    with load_generator.LoadGenerator(remote_orchestrator=remote_orchestrator, service_type=service_type):
+        start_time = time.time()
+        test_full_cycle(project=project, remote_orchestrator=remote_orchestrator)
+    end_time = time.time()
+    assert (
+        end_time - start_time
+    ) < remote_orchestrator.client.timeout, "Thread should join before timeout of the remote orchestrator client"
+
+    load_lines = [
+        "/api/v2/notification?limit=100&filter.cleared=False",
+        f"/api/v2/environment/{remote_orchestrator.environment}?details=False",
+        "/api/v2/metrics?metrics=lsm.service_count&metrics=lsm.service_instance_count&metrics=orchestrator."
+        "compile_time&metrics=orchestrator.compile_waiting_time&metrics=orchestrator.compile_rate&"
+        "metrics=resource.agent_count&metrics=resource.resource_count&start_interval=",
+        f"/lsm/v1/service_catalog/{service_type}?instance_summary=True",
+        f"/lsm/v1/service_inventory/{service_type}?include_deployment_progress=True&limit=20&sort=created_at.desc",
+        "/lsm/v1/service_catalog?instance_summary=True",
+        "/api/v2/compilereport?limit=20&sort=requested.desc",
+        "/api/v2/resource?deploy_summary=True&limit=20&sort=resource_type.asc&filter.status=orphaned",
+    ]
+    relevant_log_lines = [
+        log.message
+        for log in caplog.records
+        if any([load_line in log.message for load_line in load_lines]) and log.threadName == "Thread-LG"
+    ]
+
+    assert len(set(relevant_log_lines)) == 8, "8 different requests should be made by the LoadExecutor!"
+    assert len(relevant_log_lines) >= 8, "At least 8 requests should be made by the LoadExecutor!"
 
 
 def test_transient_state(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -178,7 +178,7 @@ def test_full_cycle_with_load_generator(
 ) -> None:
     service_type = "vlan-assignment"
 
-    with load_generator.LoadGenerator(remote_orchestrator=remote_orchestrator, service_type=service_type):
+    with load_generator.LoadGenerator(remote_orchestrator=remote_orchestrator, service_entity_name=service_type):
         start_time = time.time()
         test_full_cycle(project=project, remote_orchestrator=remote_orchestrator)
     end_time = time.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 inmanta-lsm
 pytest-inmanta
 devtools
-inmanta-module-restbase
-requests_toolbelt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 inmanta-lsm
 pytest-inmanta
 devtools
+inmanta-module-restbase
+requests_toolbelt

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -6,17 +6,13 @@
     :license: Inmanta EULA
 """
 
+import asyncio
 import datetime
-import functools
 import logging
 import threading
 import time
-from dataclasses import dataclass
 
-import inmanta_plugins.restbase.utils
-import requests
-from inmanta_plugins.restbase import handler_logger
-from requests_toolbelt.utils import dump
+from pytest_inmanta_lsm import remote_orchestrator
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,125 +48,38 @@ class LoadThread(threading.Thread):
 
         We override it to raise any exception that the Thread could have faced
         """
-        threading.Thread.join(self)
-        # Since join() returns in caller thread
+        super().join(timeout)
         # we re-raise the caught exception
         # if any was caught
         if self.exc:
             raise self.exc
 
 
-@dataclass
-class LoadTask:
-    description: str
-    urls: list[str]
-
-
-def create_list_of_tasks(environment: str, service_type: str) -> list[LoadTask]:
-    """
-    Create and return a list of pre-defined tasks
-
-    :param environment: The environment to use
-    :param service_type: The type of Service that will exist on the environment
-    """
-    current_datetime = datetime.datetime.utcnow()
-    current_formatted_datetime = current_datetime.isoformat()[:-3] + "Z"
-    to_formatted_datetime = (current_datetime + datetime.timedelta(days=7)).isoformat()[:-3] + "Z"
-
-    tasks = [
-        LoadTask(
-            description="Background load calls",
-            urls=[
-                "/api/v2/notification?limit=100&filter.cleared=false",
-                f"/api/v2/environment/{environment}?details=false",
-            ],
-        ),
-        LoadTask(
-            description="Metrics page call",
-            urls=[
-                "/api/v2/metrics?metrics=lsm.service_count&metrics=lsm.service_instance_count&metrics=orchestrator."
-                "compile_time&metrics=orchestrator.compile_waiting_time&metrics=orchestrator.compile_rate&"
-                "metrics=resource.agent_count&metrics=resource.resource_count&start_interval="
-                f"{current_formatted_datetime}&end_interval={to_formatted_datetime}&nb_datapoints=15&"
-                "round_timestamps=true"
-            ],
-        ),
-        LoadTask(description="Service catalog overview call", urls=["/lsm/v1/service_catalog?instance_summary=True"]),
-        LoadTask(
-            description="Catalog for a specific service type calls",
-            urls=[
-                f"/lsm/v1/service_catalog/{service_type}?instance_summary=True",
-                f"/lsm/v1/service_inventory/{service_type}?include_deployment_progress=True&limit=20&&sort=created_at.desc",
-            ],
-        ),
-        LoadTask(description="Compile reports call", urls=["/api/v2/compilereport?limit=20&sort=requested.desc"]),
-        LoadTask(
-            description="Resources view call",
-            urls=["/api/v2/resource?deploy_summary=True&limit=20&filter.status=%21orphaned&sort=resource_type.asc"],
-        ),
-    ]
-    return tasks
-
-
 class LoadGenerator:
     def __init__(
         self,
-        base_url: str,
-        environment: str,
+        remote_orchestrator: remote_orchestrator.RemoteOrchestrator,
         service_type: str,
+        logger: logging.Logger = LOGGER,
         sleep_time: float = 1.0,
     ):
-        self.base_url = base_url
+        self.remote_orchestrator = remote_orchestrator
+        self.service_type = service_type
         self.sleep_time = sleep_time
-
-        self.tasks = create_list_of_tasks(environment, service_type)
-        self.logger = handler_logger.LoggerWrapper(LOGGER)
-        self._session = self.init_session(environment)
+        self.logger = logger
         self._lock = threading.Lock()
         self.SHOULD_THREAD_RUN = True
-        self._thread = threading.Thread(target=self.create_load, daemon=True, name="Thread-LG")
+        self._thread = LoadThread(target=self.between_callback, daemon=True, name="Thread-LG")
 
     def __enter__(self) -> None:
-        self.logger.debug("Starting Thread %(thread)s", thread=self._thread.name)
+        self.logger.debug("Starting Thread %s", self._thread.name)
         self._thread.start()
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.change_status()
-        self.logger.debug("Stopping Thread %(thread)s", thread=self._thread.name)
+        self.logger.debug("Stopping Thread %s", self._thread.name)
         self._thread.join(30)
-        self.logger.debug("Thread %(thread)s has been stopped, closing session", thread=self._thread.name)
-        self._session.close()
-        self.logger.debug("Session has been closed")
-
-    def init_session(self, environment: str) -> requests.Session:
-        """
-        Method that is making sure that a new session is created and that every request will be logged and have a timeout on it
-        """
-        session = requests.Session()
-
-        # Make sure that we log all requests
-        session.request = functools.partial(
-            inmanta_plugins.restbase.utils.logged_request,
-            session.request,
-            self.logger,
-        )
-
-        session.request = functools.partial(
-            inmanta_plugins.restbase.utils.prefixed_request,
-            session.request,
-            self.base_url,
-        )
-
-        # Add a default timeout of 10 seconds to all requests made
-        session.request = functools.partial(
-            inmanta_plugins.restbase.utils.timeout_request,
-            session.request,
-            10,
-        )
-
-        session.headers.update({"X-Inmanta-tid": environment})
-
-        return session
+        self.logger.debug("Thread %s has been stopped, closing session", self._thread.name)
 
     def fetch_thread_status(self) -> bool:
         """
@@ -179,69 +88,112 @@ class LoadGenerator:
         with self._lock:
             return self.SHOULD_THREAD_RUN
 
-    def log_response(self, response: requests.Response):
-        """
-        Log the received response. If we are not able to dump the response, we will only log the method and the URL
-
-        :param response: The response that we need to log
-        """
-        try:
-            response.raise_for_status()
-            self.logger.debug(
-                "Thread %(thread)s - %(response)s", thread=self._thread.name, response=dump.dump_all(response).decode("utf-8")
-            )
-        except requests.RequestException:
-            try:
-                self.logger.error(
-                    "Thread %(thread)s - %(response)s",
-                    thread=self._thread.name,
-                    response=dump.dump_all(response).decode("utf-8"),
-                )
-            except UnicodeDecodeError:
-                self.logger.error(
-                    "Thread %(thread)s - Request not logged because of bad format: %(method)s %(url)s",
-                    thread=self._thread.name,
-                    method=response.request.method.upper(),
-                    url=response.url,
-                )
-        except UnicodeDecodeError:
-            self.logger.debug(
-                "Thread %(thread)s - Request not logged because of bad format: %(method)s %(url)s",
-                thread=self._thread.name,
-                method=response.request.method.upper(),
-                url=response.url,
-            )
-
-    def run_task(self, task: LoadTask) -> None:
-        """
-        Run the given task
-
-        :param task: The task that needs to be executed. A task can be composed of multiple URLs
-        """
-        self.logger.debug(task.description)
-
-        for url in task.urls:
-            response = self._session.get(url)
-            self.log_response(response)
-
-        time.sleep(self.sleep_time)
-
-    def create_load(self):
-        """
-        Loop to run provided tasks. This loop will only stop when `SHOULD_THREAD_RUN` is set to False
-        """
-        while True:
-            for task in self.tasks:
-                self.run_task(task)
-
-                should_run = self.fetch_thread_status()
-                if not should_run:
-                    return
-
     def change_status(self):
         """
         Change the `SHOULD_THREAD_RUN` status
         """
         with self._lock:
             self.SHOULD_THREAD_RUN = False
-        self.logger.debug("Thread %(thread)s should stop", thread=self._thread.name)
+        self.logger.debug("Thread %s should stop", self._thread.name)
+
+    def between_callback(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        loop.run_until_complete(self.create_load())
+        loop.close()
+
+    async def create_load(self):
+        """
+        Loop to run provided tasks. This loop will only stop when `SHOULD_THREAD_RUN` is set to False
+        """
+        start_datetime = datetime.datetime.utcnow()
+        nb_datapoints = 15
+        # start_interval and end_interval should be at least <nb_datapoints> minutes separated from each other
+        # But we need also to respect the following constraint:
+        # When round_timestamps is set to True, the number of hours between start_interval and end_interval should be
+        # at least the amount of hours equal to nb_datapoints
+        end_datetime = start_datetime + datetime.timedelta(hours=nb_datapoints + 1)
+
+        while True:
+            self.logger.debug("Thread %s - Background load calls", self._thread.name)
+            await self.remote_orchestrator.request(
+                "list_notifications",
+                tid=self.remote_orchestrator.environment,
+                limit=100,
+                filter={"cleared": False},
+            )
+            await self.remote_orchestrator.request(
+                "environment_get",
+                id=self.remote_orchestrator.environment,
+                details=False,
+            )
+
+            self.logger.debug("Thread %s - Metrics page call", self._thread.name)
+            await self.remote_orchestrator.request(
+                "get_environment_metrics",
+                tid=self.remote_orchestrator.environment,
+                metrics=[
+                    "lsm.service_count",
+                    "lsm.service_instance_count",
+                    "orchestrator.compile_time",
+                    "orchestrator.compile_waiting_time",
+                    "orchestrator.compile_rate",
+                    "resource.agent_count",
+                    "resource.resource_count",
+                ],
+                start_interval=start_datetime,
+                end_interval=end_datetime,
+                nb_datapoints=nb_datapoints,
+                round_timestamps=True,
+            )
+
+            self.logger.debug("Thread %s - Service catalog overview call", self._thread.name)
+            await self.remote_orchestrator.request(
+                "lsm_service_catalog_list",
+                tid=self.remote_orchestrator.environment,
+                instance_summary=True,
+            )
+
+            self.logger.debug("Thread %s - Catalog for a specific service type calls", self._thread.name)
+            try:
+                await self.remote_orchestrator.request(
+                    "lsm_service_catalog_get_entity",
+                    tid=self.remote_orchestrator.environment,
+                    service_entity=self.service_type,
+                    instance_summary=True,
+                )
+                await self.remote_orchestrator.request(
+                    "lsm_services_list",
+                    tid=self.remote_orchestrator.environment,
+                    service_entity=self.service_type,
+                    include_deployment_progress=True,
+                    limit=20,
+                    sort="created_at.desc",
+                )
+            except AssertionError:
+                self.logger.warning("Thread %s - Service entity `%s` not found!", self._thread.name, self.service_type)
+
+            self.logger.debug("Thread %s - Compile reports call", self._thread.name)
+            await self.remote_orchestrator.request(
+                "get_compile_reports",
+                tid=self.remote_orchestrator.environment,
+                limit=20,
+                sort="requested.desc",
+            )
+
+            self.logger.debug("Thread %s - Resources view call", self._thread.name)
+            await self.remote_orchestrator.request(
+                "resource_list",
+                tid=self.remote_orchestrator.environment,
+                deploy_summary=True,
+                limit=20,
+                filter={"status": "orphaned"},
+                sort="resource_type.asc",
+            )
+
+            should_run = self.fetch_thread_status()
+            if not should_run:
+                break
+
+            time.sleep(self.sleep_time)

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -83,6 +83,8 @@ class LoadGenerator:
         """
         Will create the load in an async manner. This method will also save any exception that could have occurred in the
         thread. This mechanism allows to raise an exception once the thread has joined, see the `__exit__` method.
+
+        It will rely on Asyncio as all the requests made by the remote orchestrator instance will be async calls
         """
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -119,10 +121,11 @@ class LoadGenerator:
         """
         start_datetime = datetime.datetime.utcnow()
         nb_datapoints = 15
-        # start_interval and end_interval should be at least <nb_datapoints> minutes separated from each other
-        # But we need also to respect the following constraint:
-        # When round_timestamps is set to True, the number of hours between start_interval and end_interval should be
-        # at least the amount of hours equals to nb_datapoints
+        # These variables will be used as input for different methods. There are some constraints that those variables need to
+        # fit it:
+        # - start_interval and end_interval should be at least <nb_datapoints> minutes separated from each other
+        # - when round_timestamps is set to True, the number of hours between start_interval and end_interval should be
+        #   at least the amount of hours equals to nb_datapoints
         end_datetime = start_datetime + datetime.timedelta(hours=nb_datapoints + 1)
 
         while True:

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -14,8 +14,6 @@ import threading
 import types
 import typing
 
-from inmanta.data import model
-
 from pytest_inmanta_lsm import remote_orchestrator
 
 LOGGER = logging.getLogger(__name__)
@@ -66,9 +64,9 @@ class LoadGenerator:
         traceback: typing.Optional[types.TracebackType],
     ) -> None:
         self.stop()
-        self.logger.debug("Stopping %s", self._thread.name)
-        self._thread.join(self.remote_orchestrator.client.timeout)
-        self.logger.debug("%s has been stopped", self._thread.name)
+        self.logger.debug("Stopping %s", self.thread.name)
+        self.thread.join(self.remote_orchestrator.client.timeout)
+        self.logger.debug("%s has been stopped", self.thread.name)
 
         if self.exception is not None:
             raise self.exception
@@ -104,7 +102,7 @@ class LoadGenerator:
         finally:
             loop.close()
 
-    async def remote_call(self, call: typing.Callable[[], typing.Awaitable[model.BaseModel]]) -> None:
+    async def remote_call(self, call: functools.partial[typing.Coroutine[typing.Any, typing.Any, None]]) -> None:
         """
         First, it ensures that the Thread should still be running, otherwise it stops. Then, it interacts with the remote
         orchestrator with the given callable function.

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -69,14 +69,14 @@ class LoadGenerator:
         """
         return self.running
 
-    def stop(self):
+    def stop(self) -> None:
         """
-        Change the `SHOULD_THREAD_RUN` status
+        Set the `running` flag to False
         """
         self.running = False
         self.logger.debug("%s should stop", self.thread.name)
 
-    def between_callback(self):
+    def between_callback(self) -> None:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
@@ -87,7 +87,7 @@ class LoadGenerator:
             self.exception = e
         loop.close()
 
-    async def remote_call(self, call: typing.Callable[[], typing.Awaitable[model.BaseModel]]):
+    async def remote_call(self, call: typing.Callable[[], typing.Awaitable[model.BaseModel]]) -> None:
         try:
             await call()
         except Exception as e:
@@ -98,9 +98,9 @@ class LoadGenerator:
 
             time.sleep(self.sleep_time)
 
-    async def create_load(self):
+    async def create_load(self) -> None:
         """
-        Loop to run provided tasks. This loop will only stop when `SHOULD_THREAD_RUN` is set to False
+        Create load until `running` flag is set to False
         """
         start_datetime = datetime.datetime.utcnow()
         nb_datapoints = 15

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -1,0 +1,221 @@
+"""
+    Pytest Inmanta LSM
+
+    :copyright: 2024 Inmanta
+    :contact: code@inmanta.com
+    :license: Inmanta EULA
+"""
+
+import datetime
+import functools
+import logging
+import threading
+import time
+from dataclasses import dataclass
+
+import inmanta_plugins.restbase.utils
+import requests
+from inmanta_plugins.restbase import handler_logger
+from requests_toolbelt.utils import dump
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Custom Thread Class
+class LoadThread(threading.Thread):
+    def run(self):
+        """Method representing the thread's activity.
+
+        The standard run() method invokes the callable object passed to the object's
+        constructor as the target argument, if any, with sequential and keyword arguments
+        taken from the args and kwargs arguments, respectively.
+
+        We override it to save any exception in the `exc` field
+        """
+        self.exc = None
+        try:
+            if self._target is not None:
+                self._target(*self._args, **self._kwargs)
+        except BaseException as e:
+            self.exc = e
+        finally:
+            # Avoid a refcycle if the thread is running a function with
+            # an argument that has a member that points to the thread.
+            del self._target, self._args, self._kwargs
+
+    def join(self, timeout=None):
+        """Wait until the thread terminates.
+
+        This blocks the calling thread until the thread whose join() method is
+        called terminates -- either normally or through an unhandled exception
+        or until the optional timeout occurs.
+
+        We override it to raise any exception that the Thread could have faced
+        """
+        threading.Thread.join(self)
+        # Since join() returns in caller thread
+        # we re-raise the caught exception
+        # if any was caught
+        if self.exc:
+            raise self.exc
+
+
+@dataclass
+class LoadTask:
+    description: str
+    urls: list[str]
+
+
+class LoadGenerator:
+    def __init__(
+        self,
+        base_url: str,
+        environment: str,
+        service_type: str,
+        sleep_time: float = 1.0,
+    ):
+        self.base_url = base_url
+        self.sleep_time = sleep_time
+
+        self.tasks = self.create_list_of_tasks(environment, service_type)
+        self.logger = handler_logger.LoggerWrapper(LOGGER)
+        self._session = self.init_session(environment)
+        self._lock = threading.Lock()
+        self.SHOULD_THREAD_RUN = True
+        self._thread = threading.Thread(target=self.create_load, daemon=True, name="Thread-LG")
+
+    def __enter__(self) -> None:
+        self.logger.debug("Starting Thread %(thread)s", thread=self._thread.name)
+        self._thread.start()
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.stop_load()
+        self.logger.debug("Stopping Thread %(thread)s", thread=self._thread.name)
+        self._thread.join(30)
+        self.logger.debug("Thread %(thread)s has been stopped, closing session", thread=self._thread.name)
+        self._session.close()
+        self.logger.debug("Session has been closed")
+
+    def init_session(self, environment: str) -> requests.Session:
+        """
+        Method that is making sure that a new session is created and that every request will be logged and have a timeout on it
+        """
+        session = requests.Session()
+
+        # Make sure that we log all requests
+        session.request = functools.partial(
+            inmanta_plugins.restbase.utils.logged_request,
+            session.request,
+            self.logger,
+        )
+
+        session.request = functools.partial(
+            inmanta_plugins.restbase.utils.prefixed_request,
+            session.request,
+            self.base_url,
+        )
+
+        # Add a default timeout of 10 seconds to all requests made
+        session.request = functools.partial(
+            inmanta_plugins.restbase.utils.timeout_request,
+            session.request,
+            10,
+        )
+
+        session.headers.update({"X-Inmanta-tid": environment})
+
+        return session
+
+    def fetch_thread_status(self) -> bool:
+        with self._lock:
+            return self.SHOULD_THREAD_RUN
+
+    def log_response(self, response: requests.Response):
+        try:
+            response.raise_for_status()
+            self.logger.debug(
+                "Thread %(thread)s - %(response)s", thread=self._thread.name, response=dump.dump_all(response).decode("utf-8")
+            )
+        except requests.RequestException:
+            try:
+                self.logger.error(
+                    "Thread %(thread)s - %(response)s",
+                    thread=self._thread.name,
+                    response=dump.dump_all(response).decode("utf-8"),
+                )
+            except UnicodeDecodeError:
+                self.logger.error(
+                    "Thread %(thread)s - Request not logged because of bad format: %(method)s %(url)s",
+                    thread=self._thread.name,
+                    method=response.request.method.upper(),
+                    url=response.url,
+                )
+        except UnicodeDecodeError:
+            self.logger.debug(
+                "Thread %(thread)s - Request not logged because of bad format: %(method)s %(url)s",
+                thread=self._thread.name,
+                method=response.request.method.upper(),
+                url=response.url,
+            )
+
+    def create_list_of_tasks(self, environment: str, service_type: str) -> list[LoadTask]:
+        current_datetime = datetime.datetime.utcnow()
+        current_formatted_datetime = current_datetime.isoformat()[:-3] + "Z"
+        to_formatted_datetime = (current_datetime + datetime.timedelta(days=7)).isoformat()[:-3] + "Z"
+
+        tasks = [
+            LoadTask(
+                description="Background load calls",
+                urls=[
+                    "/api/v2/notification?limit=100&filter.cleared=false",
+                    f"/api/v2/environment/{environment}?details=false",
+                ],
+            ),
+            LoadTask(
+                description="Metrics page call",
+                urls=[
+                    "/api/v2/metrics?metrics=lsm.service_count&metrics=lsm.service_instance_count&metrics=orchestrator."
+                    "compile_time&metrics=orchestrator.compile_waiting_time&metrics=orchestrator.compile_rate&"
+                    "metrics=resource.agent_count&metrics=resource.resource_count&start_interval="
+                    f"{current_formatted_datetime}&end_interval={to_formatted_datetime}&nb_datapoints=15&"
+                    "round_timestamps=true"
+                ],
+            ),
+            LoadTask(description="Service catalog overview call", urls=["/lsm/v1/service_catalog?instance_summary=True"]),
+            LoadTask(
+                description="Catalog for a specific service type calls",
+                urls=[
+                    f"/lsm/v1/service_catalog/{service_type}?instance_summary=True",
+                    f"/lsm/v1/service_inventory/{service_type}?include_deployment_progress=True&limit=20&&sort=created_at.desc",
+                ],
+            ),
+            LoadTask(description="Compile reports call", urls=["/api/v2/compilereport?limit=20&sort=requested.desc"]),
+            LoadTask(
+                description="Resources view call",
+                urls=["/api/v2/resource?deploy_summary=True&limit=20&filter.status=%21orphaned&sort=resource_type.asc"],
+            ),
+        ]
+        return tasks
+
+    def run_task(self, task: LoadTask) -> None:
+        self.logger.debug(task.description)
+
+        for url in task.urls:
+            response = self._session.get(url)
+            self.log_response(response)
+
+        time.sleep(self.sleep_time)
+
+    def create_load(self):
+        while True:
+            for task in self.tasks:
+                self.run_task(task)
+
+                should_run = self.fetch_thread_status()
+                if not should_run:
+                    return
+
+    def stop_load(self):
+        with self._lock:
+            self.SHOULD_THREAD_RUN = False
+        self.logger.debug("Signaling Thread %(thread)s to stop", thread=self._thread.name)

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -82,7 +82,7 @@ class LoadGenerator:
         try:
             loop.run_until_complete(self.create_load())
         except LoadException:
-            self.logger.warning("%s - Load has been stopeed!", self.thread.name)
+            self.logger.warning("%s - Load has been stopped!", self.thread.name)
         except Exception as e:
             self.exception = e
         loop.close()

--- a/src/pytest_inmanta_lsm/load_generator.py
+++ b/src/pytest_inmanta_lsm/load_generator.py
@@ -63,7 +63,8 @@ class LoadGenerator:
         exc: typing.Optional[BaseException],
         traceback: typing.Optional[types.TracebackType],
     ) -> None:
-        self.stop()
+        self.running = False
+        self.logger.debug("%s should stop", self.thread.name)
         self.logger.debug("Stopping %s", self.thread.name)
         self.thread.join(self.remote_orchestrator.client.timeout)
         self.logger.debug("%s has been stopped", self.thread.name)
@@ -77,13 +78,6 @@ class LoadGenerator:
             raise RuntimeError("The thread is not initialized, this instance should be used in a context!")
 
         return self._thread
-
-    def stop(self) -> None:
-        """
-        Set the `running` flag to False
-        """
-        self.running = False
-        self.logger.debug("%s should stop", self.thread.name)
 
     def between_callback(self) -> None:
         """

--- a/src/pytest_inmanta_lsm/remote_service_instance.pyi
+++ b/src/pytest_inmanta_lsm/remote_service_instance.pyi
@@ -29,6 +29,7 @@ class RemoteServiceInstance:
         :param service_id: manually choose the id of the service instance
         :param lookback_depth: the amount of states to search for failures if we detect a bad state
         """
+
     @property
     def instance_id(self) -> uuid.UUID: ...
     @property
@@ -38,12 +39,14 @@ class RemoteServiceInstance:
         Get the current managed service instance in its current state, and return it as a
         ServiceInstance object.
         """
+
     def history(self, *, since_version: int = 0) -> list[model.ServiceInstanceLog]:
         """
         Get the service instance history, since the specified version (included).
 
         :param since_version: The version (included) starting from which we should gather the logs.
         """
+
     def diagnose(self, *, version: int) -> FullDiagnosis:
         """
         Get a diagnosis of the service recent errors/failures, if any.
@@ -51,6 +54,7 @@ class RemoteServiceInstance:
         :param version: The version of the service at which we are looking for
             failures or errors.
         """
+
     def wait_for_state(
         self,
         target_state: str,
@@ -78,6 +82,7 @@ class RemoteServiceInstance:
         :raises StateTimeoutError: If the timeout is reached while waiting for the desired state
         :raises VersionExceededError: If version is provided and the current state goes past it
         """
+
     def create(
         self,
         attributes: dict[str, object],
@@ -102,6 +107,7 @@ class RemoteServiceInstance:
         :raises TimeoutError: If the timeout is reached while waiting for the desired state
         :raises VersionExceededError: If version is provided and the current state goes past it
         """
+
     def update(
         self,
         edit: list[model.PatchCallEdit],
@@ -128,6 +134,7 @@ class RemoteServiceInstance:
         :raises TimeoutError: If the timeout is reached while waiting for the desired state
         :raises VersionExceededError: If version is provided and the current state goes past it
         """
+
     def delete(
         self,
         *,
@@ -152,6 +159,7 @@ class RemoteServiceInstance:
         :raises TimeoutError: If the timeout is reached while waiting for the desired state
         :raises VersionExceededError: If version is provided and the current state goes past it
         """
+
     def set_state(
         self,
         state: str,

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -30,4 +30,4 @@ def test_basic_example(testdir):
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
     result = testdir.runpytest("tests/test_quickstart.py")
-    result.assert_outcomes(passed=5)
+    result.assert_outcomes(passed=6)

--- a/tests/test_containerized_orchestrator.py
+++ b/tests/test_containerized_orchestrator.py
@@ -79,4 +79,4 @@ def test_basic_example(testdir: Testdir):
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
     result = testdir.runpytest("tests/test_quickstart.py", "--lsm-ctr")
-    result.assert_outcomes(passed=5)
+    result.assert_outcomes(passed=6)


### PR DESCRIPTION
# Description

Add a load generator that will contact specific endpoints, one by one, with a configurable time between them

closes solutions/tickets#111

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
