### PR TITLE
Issue/dump orchestrator on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Add support to `LsmProject.compile` to have multiple instances selected
 - Add `LoadGenerator` helper to generate some load on the remote orchestrator
+- Add `--lsm-dump-on-failure` option, allowing to generate a support archive of the orchestrator when a test fails, and save it in the host /tmp directory.
 
 # v 3.3.0 (2024-04-15)
 Changes in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Changes in this release:
 - Add support to `LsmProject.compile` to have multiple instances selected
 - Add `LoadGenerator` helper to generate some load on the remote orchestrator
-- Add `--lsm-dump-on-failure` option, allowing to generate a support archive of the orchestrator when a test fails, and save it in the host /tmp directory.
+- Add `--lsm-dump-on-failure` option, allowing to generate a support archive of the orchestrator when a test fails, and save it in the host /tmp directory. (#409)
 
 # v 3.3.0 (2024-04-15)
 Changes in this release:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ pytest-inmanta-lsm:
                         The token used to authenticate to the remote
                         orchestrator when authentication is enabled. (overrides
                         INMANTA_LSM_TOKEN)
+  --lsm-dump-on-failure
+                        Whether to create and save a support archive when a test fails.
+                        The support archive will be saved in the /tmp directory of the
+                        host running the test and will not be cleaned up. The value of
+                        this option can be overwritten for each test case individually
+                        by overwriting the value of the remote_orchestrator_dump_on_failure
+                        fixture. (overrides INMANTA_LSM_DUMP_ON_FAILURE, defaults to False)
 
 ```
 

--- a/examples/test_service/tests/test_deployment_failure.py
+++ b/examples/test_service/tests/test_deployment_failure.py
@@ -31,19 +31,10 @@ def test_full_cycle(project, remote_orchestrator, fail: bool):
 
     service_instance = remote_orchestrator.get_managed_instance(SERVICE_NAME)
 
-    def create() -> None:
-        """
-        create an instance and wait for it to be up
-        """
-
-        service_instance.create(
-            attributes={"service_id": "id", "fail": fail},
-            wait_for_state="up",
-            bad_states=["rejected", "failed", "deleting", "create_failed"],
-        )
-
-    if fail:
-        with pytest.raises(RuntimeError):
-            create()
-    else:
-        create()
+    # Create an instance and wait for it to be up, if fail==True, let the
+    # test fail, to test pytest-inmanta-lsm in a context where the test didn't pass.
+    service_instance.create(
+        attributes={"service_id": "id", "fail": fail},
+        wait_for_state="up",
+        bad_states=["rejected", "failed", "deleting", "create_failed"],
+    )

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -240,3 +240,16 @@ inm_lsm_ctr_env = PathTestParameter(
     exists=True,
     is_file=True,
 )
+
+inm_lsm_dump = BooleanTestParameter(
+    argument="--lsm-dump-on-failure",
+    environment_variable="INMANTA_LSM_DUMP_ON_FAILURE",
+    usage=(
+        "Whether to create and save a support archive when a test fails.  The support "
+        "archive will be saved in the /tmp directory of the host running the test and will not be cleaned up.  "
+        "The value of this option can be overwritten for each test case individually by overwriting the "
+        "value of the remote_orchestrator_dump_on_failure fixture."
+    ),
+    default=False,
+    group=param_group,
+)

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -94,7 +94,8 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) ->
 
     # store test results for each phase of a call, which can
     # be "setup", "call", "teardown"
-    item.stash.setdefault(phase_report_key, {})[rep.when] = rep
+    default: dict = {}
+    item.stash.setdefault(phase_report_key, default)[rep.when] = rep
 
 
 @pytest.fixture(name="lsm_project")

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -478,7 +478,7 @@ def remote_orchestrator(
         # This version is too old, we can't create the dump, log a warning and
         # exit here
         LOGGER.warning(
-            "Orchestrator version (%s) doesn't have the api call we need to dump " "the support archive: /api/v2/support",
+            "Orchestrator version (%s) doesn't have the api call we need to dump the support archive: /api/v2/support",
             remote_orchestrator_shared.server_version,
         )
         return

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -336,15 +336,14 @@ def remote_orchestrator_access(
     # Make sure the remote orchestrator is running
     for _ in range(0, 10):
         try:
-            response = remote_orchestrator.session.get("/api/v1/serverstatus", timeout=2)
-            response.raise_for_status()
-        except Exception as exc:
+            # Try to get the version of the server, if we can't get it, the server
+            # is not reachable (yet)
+            remote_orchestrator.server_version
+            return remote_orchestrator
+        except AssertionError as exc:
             LOGGER.warning(str(exc))
             time.sleep(1)
             continue
-
-        if response.status_code == 200:
-            return remote_orchestrator
 
     raise RuntimeError(f"Couldn't reach the orchestrator at {host}:{port}")
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -258,8 +258,8 @@ class RemoteOrchestrator:
         # Setting up the client when the config is loaded
         self.setup_config()
 
-        self.orchestrator_environment.configure_environment(self.client)
-        self.server_version = self._get_server_version()
+        # Save the version of the remote orchestrator server
+        self._server_version: typing.Optional[Version] = None
 
         # The path on the remote orchestrator where the project will be synced
         self.remote_project_path = pathlib.Path(
@@ -395,6 +395,18 @@ class RemoteOrchestrator:
                 return pydantic.parse_obj_as(returned_type, response.result["data"])
         else:
             return None
+
+    @property
+    def server_version(self) -> Version:
+        """
+        Get the version of the remote orchestrator.  The version is not expected to change
+        for the duration of the test case, so that value is cached after the first call.
+        """
+        if self._server_version is not None:
+            return self._server_version
+
+        self._server_version = self._get_server_version()
+        return self._server_version
 
     def _get_server_version(self) -> Version:
         """

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -346,7 +346,7 @@ class RemoteOrchestrator:
 
         # Setup base url for all requests made
         def request_with_base_url(
-            request: typing.Callable, method: str, base_url: str, url: str, *args: object, **kwargs: object
+            request: typing.Callable, base_url: str, method: str, url: str, *args: object, **kwargs: object
         ) -> requests.Response:
             return request(
                 method,

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -346,9 +346,10 @@ class RemoteOrchestrator:
 
         # Setup base url for all requests made
         def request_with_base_url(
-            request: typing.Callable, base_url: str, url: str, *args: object, **kwargs: object
+            request: typing.Callable, method: str, base_url: str, url: str, *args: object, **kwargs: object
         ) -> requests.Response:
             return request(
+                method,
                 urllib.parse.urljoin(base_url, url),
                 *args,
                 **kwargs,

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -26,10 +26,12 @@ def test_deployment_failure(testdir: pytest.Testdir):
     result.assert_outcomes(passed=1, failed=1)
 
     # Check that the dump has been created
-    search_line = re.compile(r"(.*)INFO(.*)Support archive of orchestrator has been saved at (.*)")
+    search_line = re.compile(
+        r"INFO\s+pytest_inmanta_lsm\.plugin:plugin\.py:\d+\s+Support archive of orchestrator has been saved at (?P<path>.*)"
+    )
     matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
     assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
-    assert pathlib.Path(matched_lines[0].group(1)).exists()
+    assert pathlib.Path(matched_lines[0].group("path")).exists()
 
 
 def test_basic_example(testdir):

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -8,18 +8,28 @@
 
 # Note: These tests only function when the pytest output is not modified by plugins such as pytest-sugar!
 
+import pathlib
+import re
+
+import pytest
 import utils
 
 
-def test_deployment_failure(testdir):
+def test_deployment_failure(testdir: pytest.Testdir):
     """Testing that a failed test doesn't make the plugin fail"""
 
     testdir.copy_example("test_service")
 
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
-    result = testdir.runpytest_inprocess("tests/test_deployment_failure.py")
-    result.assert_outcomes(passed=2)
+    result = testdir.runpytest_inprocess("tests/test_deployment_failure.py", "--lsm-dump-on-failure")
+    result.assert_outcomes(passed=1, failed=1)
+
+    # Check that the dump has been created
+    search_line = re.compile(r"(.*)INFO(.*)Support archive of orchestrator has been saved at (.*)")
+    matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
+    assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
+    assert pathlib.Path(matched_lines[0].group(1)).exists()
 
 
 def test_basic_example(testdir):

--- a/tests/test_basic_example.py
+++ b/tests/test_basic_example.py
@@ -30,7 +30,7 @@ def test_deployment_failure(testdir: pytest.Testdir):
         r"INFO\s+pytest_inmanta_lsm\.plugin:plugin\.py:\d+\s+Support archive of orchestrator has been saved at (?P<path>.*)"
     )
     matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
-    assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
+    assert len(matched_lines) >= 1, f"Failed to find dump log in test output: {result.stdout.str()}"
     assert pathlib.Path(matched_lines[0].group("path")).exists()
 
 

--- a/tests/test_containerized_orchestrator.py
+++ b/tests/test_containerized_orchestrator.py
@@ -77,7 +77,7 @@ def test_deployment_failure(testdir: Testdir):
         r"INFO\s+pytest_inmanta_lsm\.plugin:plugin\.py:\d+\s+Support archive of orchestrator has been saved at (?P<path>.*)"
     )
     matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
-    assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
+    assert len(matched_lines) >= 1, f"Failed to find dump log in test output: {result.stdout.str()}"
     assert pathlib.Path(matched_lines[0].group("path")).exists()
 
 

--- a/tests/test_containerized_orchestrator.py
+++ b/tests/test_containerized_orchestrator.py
@@ -73,10 +73,12 @@ def test_deployment_failure(testdir: Testdir):
     result.assert_outcomes(passed=1, failed=1)
 
     # Check that the dump has been created
-    search_line = re.compile(r"(.*)INFO(.*)Support archive of orchestrator has been saved at (.*)")
+    search_line = re.compile(
+        r"INFO\s+pytest_inmanta_lsm\.plugin:plugin\.py:\d+\s+Support archive of orchestrator has been saved at (?P<path>.*)"
+    )
     matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
     assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
-    assert pathlib.Path(matched_lines[0].group(1)).exists()
+    assert pathlib.Path(matched_lines[0].group("path")).exists()
 
 
 def test_basic_example(testdir: Testdir):

--- a/tests/test_containerized_orchestrator.py
+++ b/tests/test_containerized_orchestrator.py
@@ -9,9 +9,11 @@
 # Note: These tests only function when the pytest output is not modified by plugins such as pytest-sugar!
 
 import os
+import pathlib
+import re
 import shutil
 import subprocess
-from pathlib import Path
+import typing
 
 import utils
 from pytest import Testdir, fixture
@@ -20,7 +22,7 @@ HOME = os.getenv("HOME", "")
 
 
 @fixture
-def testdir(testdir: Testdir) -> Testdir:
+def testdir(testdir: Testdir) -> typing.Iterator[Testdir]:
     """
     This fixture ensure that when changing the home directory with the testdir
     fixture we also copy any docker client config that was there.
@@ -33,7 +35,7 @@ def testdir(testdir: Testdir) -> Testdir:
             os.path.join(testdir.tmpdir, ".docker"),
         )
 
-    ssh_dir = Path(HOME) / ".ssh"
+    ssh_dir = pathlib.Path(HOME) / ".ssh"
     private_key = ssh_dir / "id_rsa"
     public_key = ssh_dir / "id_rsa.pub"
 
@@ -67,8 +69,14 @@ def test_deployment_failure(testdir: Testdir):
 
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
-    result = testdir.runpytest_inprocess("tests/test_deployment_failure.py", "--lsm-ctr")
-    result.assert_outcomes(passed=2)
+    result = testdir.runpytest_inprocess("tests/test_deployment_failure.py", "--lsm-ctr", "--lsm-dump-on-failure")
+    result.assert_outcomes(passed=1, failed=1)
+
+    # Check that the dump has been created
+    search_line = re.compile(r"(.*)INFO(.*)Support archive of orchestrator has been saved at (.*)")
+    matched_lines = [match for line in result.stdout.lines if (match := search_line.fullmatch(line)) is not None]
+    assert len(matched_lines) == 1, f"Failed to find dump log in test output: {result.stdout.str()}"
+    assert pathlib.Path(matched_lines[0].group(1)).exists()
 
 
 def test_basic_example(testdir: Testdir):


### PR DESCRIPTION
# Description

Add `--lsm-dump-on-failure` option, allowing to generate a support archive of the orchestrator when a test fails, and save it in the host /tmp directory.

closes #409 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
