### PR TITLE
Issue/fix wait for transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes in this release:
 - Add support to `LsmProject.compile` to have multiple instances selected
 - Add `LoadGenerator` helper to generate some load on the remote orchestrator
 - Add `--lsm-dump-on-failure` option, allowing to generate a support archive of the orchestrator when a test fails, and save it in the host /tmp directory. (#409)
+- Fix race condition in `RemoteServiceInstance.wait_for_state` that would make it return a `ServiceInstance` with a different version that the one we asked the method to wait for.
 
 # v 3.3.0 (2024-04-15)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/remote_service_instance_async.py
+++ b/src/pytest_inmanta_lsm/remote_service_instance_async.py
@@ -247,7 +247,8 @@ class RemoteServiceInstance:
         start_version: int,
     ) -> model.ServiceInstance:
         """
-        Wait for this service instance to reach the desired target state.
+        Wait for this service instance to reach the desired target state.  Returns a ServiceInstance
+        object that is in the state that was waited for.
 
         :param target_state: The state we want to wait our service instance to reach.
         :param target_version: The version the service is expected to be in once we reached the target
@@ -258,8 +259,8 @@ class RemoteServiceInstance:
         :param timeout: The time, in seconds, after which we should stop waiting and
             raise a StateTimeoutError.  If set to None, uses the DEFAULT_TIMEOUT attribute of the
             object.
-        :param start_version: The initial version we know the service has been in, we only
-            look for versions after this one.
+        :param start_version: A service version from which we should search for the target state.
+            This version and all of the prior versions will not be checked for a match as the target state.
         :raises BadStateError: If the instance went into a bad state
         :raises StateTimeoutError: If the timeout is reached while waiting for the desired state
         :raises VersionExceededError: If version is provided and the current state goes past it


### PR DESCRIPTION
# Description

Fix race condition in `RemoteServiceInstance.wait_for_state` that would make it return a `ServiceInstance` with a different version that the one we asked the method to wait for.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
