### PR TITLE
Issue/support ng containers

### DIFF
--- a/.ci-integration-tests-iso8.yml
+++ b/.ci-integration-tests-iso8.yml
@@ -19,7 +19,7 @@ env_vars:
     # The INMANTA_LSM_CONTAINER environment variable is not set here. The test suite sets the
     # --lsm-ctr option for the subset of tests that need to run against a docker container.
     # More information regarding the structure of the test suite can be found in the README.md
-    INMANTA_LSM_CONTAINER_IMAGE: code.inmanta.com:4567/solutions/containers/service-orchestrator:8-dev
+    INMANTA_LSM_CONTAINER_IMAGE: code.inmanta.com:4567/solutions/containers/service-orchestrator:8-dev-ng
     INMANTA_LSM_CONTAINER_LICENSE_FILE: /etc/inmanta/license/jenkins.inmanta.com.license
     INMANTA_LSM_CONTAINER_JWE_FILE: /etc/inmanta/license/jenkins.inmanta.com.jwe
     # only add package repo, git repo requires token and is added in the Jenkinsfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.7.0 (?)
 Changes in this release:
+- Add support for ng containers.
 
 # v 3.6.0 (2024-07-24)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -145,7 +145,7 @@ def remote_orchestrator_container(
         # the default legacy one (for <iso7.1).  To decide which one is the most
         # appropriate, we parse the container image tag and extract the iso version
         iso_major_version_match = re.fullmatch(
-            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(\-dev|\-rc|\-dev-ng)?|dev|dev\-ng)",
+            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(-dev|-rc|-dev-ng)?|dev|dev-ng)",
             orchestrator_image,
         )
         if not iso_major_version_match:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -145,7 +145,7 @@ def remote_orchestrator_container(
         # the default legacy one (for <iso7.1).  To decide which one is the most
         # appropriate, we parse the container image tag and extract the iso version
         iso_major_version_match = re.fullmatch(
-            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(\-dev|\-rc|\-dev-ng)?|dev|dev-ng)",
+            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(\-dev|\-rc|\-dev-ng)?|dev|dev\-ng)",
             orchestrator_image,
         )
         if not iso_major_version_match:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -145,7 +145,7 @@ def remote_orchestrator_container(
         # the default legacy one (for <iso7.1).  To decide which one is the most
         # appropriate, we parse the container image tag and extract the iso version
         iso_major_version_match = re.fullmatch(
-            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(\-dev|\-rc)?|dev)",
+            r".*\/service-orchestrator:(?P<tag>(?P<version>\d+(\.\d+)*)(\-dev|\-rc|\-dev-ng)?|dev|dev-ng)",
             orchestrator_image,
         )
         if not iso_major_version_match:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -158,7 +158,7 @@ def remote_orchestrator_container(
                 str(legacy_compose_file),
             )
             compose_file = legacy_compose_file
-        elif iso_major_version_match.group("tag") == "dev":
+        elif iso_major_version_match.group("tag") in ["dev", "dev-ng"]:
             # Latest dev, use the the latest compose file, this is always safe because we don't distribute this externally
             compose_file = latest_compose_file
         elif version.Version(iso_major_version_match.group("version")) >= version.Version("7.1"):

--- a/src/pytest_inmanta_lsm/resources/docker-compose.yml
+++ b/src/pytest_inmanta_lsm/resources/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       INMANTA_DATABASE_PASSWORD: inmanta
       INMANTA_SERVER_BIND_ADDRESS: "0.0.0.0"
       INMANTA_SERVER_BIND_PORT: 8888
+      INMANTA_LICENSE_ENTITLEMENT_FILE: /etc/inmanta/license/com.inmanta.jwe
+      INMANTA_LICENSE_LICENSE_KEY: /etc/inmanta/license/com.inmanta.license
     volumes:
       - ${INMANTA_LSM_CONTAINER_LICENSE_FILE}:/etc/inmanta/license/com.inmanta.license
       - ${INMANTA_LSM_CONTAINER_ENTITLEMENT_FILE}:/etc/inmanta/license/com.inmanta.jwe


### PR DESCRIPTION
# Description

- Make sure that pytest-inmanta-lsm can be used with latest ng containers

Blocked by https://github.com/inmanta/inmanta-service-orchestrator/pull/507

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
