### PR TITLE
Issue/allow url license path

### DIFF
--- a/.ci-integration-tests-iso8.yml
+++ b/.ci-integration-tests-iso8.yml
@@ -20,8 +20,8 @@ env_vars:
     # --lsm-ctr option for the subset of tests that need to run against a docker container.
     # More information regarding the structure of the test suite can be found in the README.md
     INMANTA_LSM_CONTAINER_IMAGE: code.inmanta.com:4567/solutions/containers/service-orchestrator:8-dev-ng
-    INMANTA_LSM_CONTAINER_LICENSE_FILE: /etc/inmanta/license/jenkins.inmanta.com.license
-    INMANTA_LSM_CONTAINER_JWE_FILE: /etc/inmanta/license/jenkins.inmanta.com.jwe
+    INMANTA_LSM_CONTAINER_LICENSE_FILE: http://file.ii.inmanta.com/license/dev.inmanta.com.license
+    INMANTA_LSM_CONTAINER_JWE_FILE: http://file.ii.inmanta.com/license/dev.inmanta.com.jwe
     # only add package repo, git repo requires token and is added in the Jenkinsfile
     INMANTA_MODULE_REPO: "package:https://artifacts.internal.inmanta.com/inmanta/dev"
 directories_to_lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.8.0 (?)
 Changes in this release:
+- Add support for loading license/entitlement file from http url.
 
 # v 3.7.0 (2024-08-12)
 Changes in this release:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     packages=["pytest_inmanta_lsm"],
     package_data={
         "pytest_inmanta_lsm": [
+            "resources/docker-compose-http-license.yml",
             "resources/docker-compose-legacy.yml",
             "resources/docker-compose.yml",
             "resources/my-env-file",

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -99,8 +99,8 @@ class OrchestratorContainer:
         orchestrator_image: str,
         postgres_version: str,
         public_key_file: Path,
-        license_file: Path,
-        entitlement_file: Path,
+        license_file: str,
+        entitlement_file: str,
         config_file: Path,
         env_file: Path,
     ) -> None:

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -204,20 +204,16 @@ inm_lsm_ctr_license = StringTestParameter(
     argument="--lsm-ctr-license-file",
     environment_variable="INMANTA_LSM_CONTAINER_LICENSE_FILE",
     usage="A path to a license file, required by the orchestrator",
-    default=Path("/etc/inmanta/license/com.inmanta.license"),
+    default="/etc/inmanta/license/com.inmanta.license",
     group=param_group,
-    exists=True,
-    is_file=True,
 )
 
 inm_lsm_ctr_entitlement = StringTestParameter(
     argument="--lsm-ctr-jwe-file",
     environment_variable="INMANTA_LSM_CONTAINER_JWE_FILE",
     usage="A path to an entitlement file, required by the orchestrator",
-    default=Path("/etc/inmanta/license/com.inmanta.jwe"),
+    default="/etc/inmanta/license/com.inmanta.jwe",
     group=param_group,
-    exists=True,
-    is_file=True,
 )
 
 inm_lsm_ctr_config = PathTestParameter(

--- a/src/pytest_inmanta_lsm/parameters.py
+++ b/src/pytest_inmanta_lsm/parameters.py
@@ -200,7 +200,7 @@ inm_lsm_ctr_pub_key = PathTestParameter(
     is_file=True,
 )
 
-inm_lsm_ctr_license = PathTestParameter(
+inm_lsm_ctr_license = StringTestParameter(
     argument="--lsm-ctr-license-file",
     environment_variable="INMANTA_LSM_CONTAINER_LICENSE_FILE",
     usage="A path to a license file, required by the orchestrator",
@@ -210,7 +210,7 @@ inm_lsm_ctr_license = PathTestParameter(
     is_file=True,
 )
 
-inm_lsm_ctr_entitlement = PathTestParameter(
+inm_lsm_ctr_entitlement = StringTestParameter(
     argument="--lsm-ctr-jwe-file",
     environment_variable="INMANTA_LSM_CONTAINER_JWE_FILE",
     usage="A path to an entitlement file, required by the orchestrator",

--- a/src/pytest_inmanta_lsm/resources/docker-compose-http-license.yml
+++ b/src/pytest_inmanta_lsm/resources/docker-compose-http-license.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  postgres:
+    container_name: ${INMANTA_LSM_CONTAINER_DB_HOSTNAME}
+    image: postgres:${INMANTA_LSM_CONTAINER_DB_VERSION}
+    environment:
+      POSTGRES_USER: inmanta
+      POSTGRES_PASSWORD: inmanta
+
+  inmanta-server:
+    image: ${INMANTA_LSM_CONTAINER_ORCHESTRATOR_IMAGE}
+    entrypoint: ["/usr/bin/inmanta"]
+    env_file: ["./my-env-file"]
+    user: inmanta:inmanta
+    environment:
+      INMANTA_DATABASE_HOST: ${INMANTA_LSM_CONTAINER_DB_HOSTNAME}
+      INMANTA_DATABASE_USERNAME: inmanta
+      INMANTA_DATABASE_PASSWORD: inmanta
+      INMANTA_SERVER_BIND_ADDRESS: "0.0.0.0"
+      INMANTA_SERVER_BIND_PORT: 8888
+      INMANTA_LICENSE_ENTITLEMENT_FILE: ${INMANTA_LSM_CONTAINER_ENTITLEMENT_FILE}
+      INMANTA_LICENSE_LICENSE_KEY: ${INMANTA_LSM_CONTAINER_LICENSE_FILE}
+    command: "--log-file /var/log/inmanta/server.log --log-file-level DEBUG --timed-logs server --db-wait-time 10"


### PR DESCRIPTION
# Description

Natively support http urls for license/entitlement files for auto-started orchestrator.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
