### PR TITLE
Issue/iso 7 dev supports latest compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.9.0 (?)
 Changes in this release:
+- Allow iso 7-dev containers to be deployed with latest docker-compose file.
 
 # v 3.8.0 (2024-08-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -159,7 +159,7 @@ def remote_orchestrator_container(
                 str(legacy_compose_file),
             )
             compose_file = legacy_compose_file
-        elif iso_major_version_match.group("tag") in ["dev", "dev-ng"]:
+        elif iso_major_version_match.group("tag") in ["7-dev", "dev", "dev-ng"]:
             # Latest dev, use the the latest compose file, this is always safe because we don't distribute this externally
             compose_file = latest_compose_file
         elif version.Version(iso_major_version_match.group("version")) >= version.Version("7.1"):


### PR DESCRIPTION
# Description

- Add 7-dev to the list of dev tags which can be considered recent enough to use the non-legacy docker-compose

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
