### PR TITLE
Add support for new docker compose command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes in this release:
 - Extends the mocking mechanism to support the LSM Transfer Optimization feature
 - Allow iso 7-dev containers to be deployed with latest docker-compose file.
 - Add init process and healthcheck to orchestrator containers started by pytest-inmanta-lsm
+- Allow `docker-compose` and `docker compose` commands
 
 # v 3.8.0 (2024-08-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -226,7 +226,7 @@ class OrchestratorContainer:
             return ["docker-compose"]
         except FileNotFoundError:
             try:
-                subprocess.run(args=["docker-compose", "--help"])
+                subprocess.run(args=["docker", "compose", "--help"])
                 return ["docker", "compose"]
             except FileNotFoundError:
                 raise FileNotFoundError(

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -222,11 +222,11 @@ class OrchestratorContainer:
     @property
     def docker_compose(self) -> list[str]:
         try:
-            run_cmd(cmd=["docker-compose", "--help"], cwd=self.cwd)
+            subprocess.run(args=["docker-compose", "--help"])
             return ["docker-compose"]
         except FileNotFoundError:
             try:
-                run_cmd(cmd=["docker", "compose", "--help"], cwd=self.cwd)
+                subprocess.run(args=["docker-compose", "--help"])
                 return ["docker", "compose"]
             except FileNotFoundError:
                 raise FileNotFoundError(

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -222,11 +222,11 @@ class OrchestratorContainer:
     @property
     def docker_compose(self) -> list[str]:
         try:
-            run_cmd(cmd=["docker-compose", "--help"])
+            run_cmd(cmd=["docker-compose", "--help"], cwd=self.cwd)
             return ["docker-compose"]
         except FileNotFoundError:
             try:
-                run_cmd(cmd=["docker", "compose", "--help"])
+                run_cmd(cmd=["docker", "compose", "--help"], cwd=self.cwd)
                 return ["docker", "compose"]
             except FileNotFoundError:
                 raise FileNotFoundError(

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -236,20 +236,20 @@ class OrchestratorContainer:
 
     def _up(self) -> None:
         # Pull container images
-        cmd = [*self.docker_compose(), f"--file={self.compose_file.name}", "--verbose", "pull"]
+        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "pull"]
         run_cmd(cmd=cmd, cwd=self.cwd)
         # Starting the lab
-        cmd = [*self.docker_compose(), f"--file={self.compose_file.name}", "--verbose", "up", "-d"]
+        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "up", "-d"]
         run_cmd(cmd=cmd, cwd=self.cwd)
 
         # Getting the containers ids
-        cmd = [*self.docker_compose(), f"--file={self.compose_file.name}", "--verbose", "ps", "-q"]
+        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "ps", "-q"]
         stdout, _ = run_cmd(cmd=cmd, cwd=self.cwd)
         self._containers = stdout.strip("\n").split("\n")
 
     def _down(self) -> None:
         # Stopping the lab
-        cmd = ["docker-compose", f"--file={self.compose_file.name}", "--verbose", "down", "-v"]
+        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "down", "-v"]
         run_cmd(cmd=cmd, cwd=self.cwd)
 
     def __enter__(self) -> "OrchestratorContainer":
@@ -273,7 +273,7 @@ class OrchestratorContainer:
         if exc_type == DoNotCleanOrchestratorContainer:
             LOGGER.info(
                 "The orchestrator won't be cleaned up, do it manually once you are done with it.  "
-                f"`cd {self._cwd} && docker-compose down -v`"
+                f"`cd {self._cwd} && {' '.join(self.docker_compose)} down -v`"
             )
             return True
 

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -384,7 +384,7 @@ def remote_orchestrator_access(
     )
 
     # Make sure the remote orchestrator is running
-    for _ in range(0, 10):
+    for _ in range(0, 20):
         try:
             # Try to get the status of the server, use the session object to set
             # a custom timeout

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -384,7 +384,7 @@ def remote_orchestrator_access(
     )
 
     # Make sure the remote orchestrator is running
-    for _ in range(0, 20):
+    for _ in range(0, 10):
         try:
             # Try to get the status of the server, use the session object to set
             # a custom timeout


### PR DESCRIPTION
# Description

Jenkins runner 11 uses `docker compose` instead of `docker-compose`

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
