### PR TITLE
fix typing errors and lazily fetch remote project path in remote orchestrator fixture

### DIFF
--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -395,7 +395,6 @@ def remote_orchestrator_access(
             time.sleep(1)
     else:
         raise RuntimeError(f"Couldn't reach the orchestrator at {host}:{port}")
-    remote_orchestrator.sync_remote_project_path()
 
     # Configure the environment on the remote orchestrator
     remote_orchestrator.orchestrator_environment.configure_environment(remote_orchestrator.client)

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -465,7 +465,6 @@ class RemoteOrchestrator:
         This path depends on the on-disk layout of the remote orchestrator.
         """
         if self._remote_project_path is None:
-
             cmd = "if test -f /var/lib/inmanta/.inmanta_use_new_disk_layout ; then echo True ; fi"
             use_new_disk_layout: bool = self.run_command([cmd], shell=True, user=None, stderr=subprocess.PIPE).strip() == "True"
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -262,11 +262,10 @@ class RemoteOrchestrator:
         # Save the version of the remote orchestrator server
         self._server_version: typing.Optional[Version] = None
 
-        # The path on the remote orchestrator where the project will be synced.
-        # This path is determined once the orchestrator
-        # is up and running by calling sync_remote_project_path()
-        self.remote_project_path: typing.Optional[str] = None
-        self.remote_project_cache_path: typing.Optional[str] = None
+        # Cached value of the path to the project on the remote orchestrator
+        self._remote_project_path: typing.Optional[pathlib.Path] = None
+        # Cached value of the path to the project's cache on the remote orchestrator
+        self._remote_project_cache_path: typing.Optional[pathlib.Path] = None
 
     @property
     def local_project(self) -> inmanta.module.Project:
@@ -282,23 +281,6 @@ class RemoteOrchestrator:
             )
 
         return project
-
-    def sync_remote_project_path(self):
-        """
-        Determine where the local project should be synced on the remote orchestrator.
-        This path depends on the on-disk layout of the remote orchestrator.
-        """
-        cmd = "if test -f /var/lib/inmanta/.inmanta_use_new_disk_layout ; then echo True ; fi"
-        use_new_disk_layout: bool = self.run_command([cmd], shell=True, user=None, stderr=subprocess.PIPE).strip() == "True"
-
-        if use_new_disk_layout:
-            self.remote_project_path = pathlib.Path("/var/lib/inmanta/server/", str(self.environment), "compiler")
-        else:
-            self.remote_project_path = pathlib.Path(
-                "/var/lib/inmanta/server/environments/",
-                str(self.environment),
-            )
-        self.remote_project_cache_path = self.remote_project_path.with_name(self.remote_project_path.name + "_cache")
 
     def setup_config(self) -> None:
         """
@@ -475,6 +457,37 @@ class RemoteOrchestrator:
             self._whoami = self.run_command(["whoami"], user=None, stderr=subprocess.PIPE).strip()
             LOGGER.debug("Remote user at %s (accessed via %s) is %s", self.remote_host, self.remote_shell, repr(self._whoami))
         return self._whoami
+
+    @property
+    def remote_project_path(self) -> pathlib.Path:
+        """
+        Path on the remote orchestrator where the local project should be synced to.
+        This path depends on the on-disk layout of the remote orchestrator.
+        """
+        if self._remote_project_path is None:
+
+            cmd = "if test -f /var/lib/inmanta/.inmanta_use_new_disk_layout ; then echo True ; fi"
+            use_new_disk_layout: bool = self.run_command([cmd], shell=True, user=None, stderr=subprocess.PIPE).strip() == "True"
+
+            if use_new_disk_layout:
+                self._remote_project_path = pathlib.Path("/var/lib/inmanta/server/", str(self.environment), "compiler")
+            else:
+                self._remote_project_path = pathlib.Path(
+                    "/var/lib/inmanta/server/environments/",
+                    str(self.environment),
+                )
+
+        return self._remote_project_path
+
+    @property
+    def remote_project_cache_path(self) -> pathlib.Path:
+        """
+        Path on the remote orchestrator where the project's cache will live.
+        """
+        if self._remote_project_cache_path is None:
+            self._remote_project_cache_path = self.remote_project_path.with_name(self.remote_project_path.name + "_cache")
+
+        return self._remote_project_cache_path
 
     def run_command(
         self,


### PR DESCRIPTION
As per [slack discussion](https://inmanta.slack.com/archives/CKRF0C8R3/p1730124012981849)

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
