### PR TITLE
Issue/simpler docker compose folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes in this release:
 - Allow iso 7-dev containers to be deployed with latest docker-compose file.
 - Add init process and healthcheck to orchestrator containers started by pytest-inmanta-lsm
 - Allow `docker-compose` and `docker compose` commands
+- Make sure that auto-started containerized orchestrator can always be stopped with `docker compose down -v`
 
 # v 3.8.0 (2024-08-20)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -140,6 +140,11 @@ class OrchestratorContainer:
         docker_compose_dir = self.compose_file.parent
         shutil.copytree(str(docker_compose_dir), str(self._cwd), dirs_exist_ok=True)
 
+        # Make sure our compose topology is named docker-compose.yml, this makes the cleanup
+        # a lot easier if anyone comes across the folder
+        if self.compose_file.name != "docker-compose.yml":
+            self.compose_file = self.compose_file.replace(self.compose_file.with_name("docker-compose.yml"))
+
         shutil.copy(str(self.config_file), str(self._cwd / "my-server-conf.cfg"))
         shutil.copy(str(self.env_file), str(self._cwd / "my-env-file"))
 
@@ -238,20 +243,20 @@ class OrchestratorContainer:
 
     def _up(self) -> None:
         # Pull container images
-        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "pull"]
+        cmd = [*self.docker_compose, "--verbose", "pull"]
         run_cmd(cmd=cmd, cwd=self.cwd)
         # Starting the lab
-        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "up", "-d"]
+        cmd = [*self.docker_compose, "--verbose", "up", "-d"]
         run_cmd(cmd=cmd, cwd=self.cwd)
 
         # Getting the containers ids
-        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "ps", "-q"]
+        cmd = [*self.docker_compose, "--verbose", "ps", "-q"]
         stdout, _ = run_cmd(cmd=cmd, cwd=self.cwd)
         self._containers = stdout.strip("\n").split("\n")
 
     def _down(self) -> None:
         # Stopping the lab
-        cmd = [*self.docker_compose, f"--file={self.compose_file.name}", "--verbose", "down", "-v"]
+        cmd = [*self.docker_compose, "--verbose", "down", "-v"]
         run_cmd(cmd=cmd, cwd=self.cwd)
 
     def __enter__(self) -> "OrchestratorContainer":

--- a/src/pytest_inmanta_lsm/orchestrator_container.py
+++ b/src/pytest_inmanta_lsm/orchestrator_container.py
@@ -143,7 +143,7 @@ class OrchestratorContainer:
         # Make sure our compose topology is named docker-compose.yml, this makes the cleanup
         # a lot easier if anyone comes across the folder
         if self.compose_file.name != "docker-compose.yml":
-            self.compose_file = self.compose_file.replace(self.compose_file.with_name("docker-compose.yml"))
+            (self._cwd / self.compose_file.name).replace(self._cwd / "docker-compose.yml")
 
         shutil.copy(str(self.config_file), str(self._cwd / "my-server-conf.cfg"))
         shutil.copy(str(self.env_file), str(self._cwd / "my-env-file"))


### PR DESCRIPTION
# Description

This job failed at the end, because it tries to cleanup any docker compose topology it finds on the runner (which might have been leaked by any similar test suite), but the docker compose file used there was not named `docker-compose.yml`, which is hard to figure out for this simple cleanup script.
https://jenkins.inmanta.com/job/integration-tests/job/inmanta-service-orchestrator-connect/job/master/1012/consoleFull

This PR makes sure we always name the file `docker-compose.yml`, for simplified cleanup down the road

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
