### PR TITLE
Issue/never clear protected env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 3.10.0 (?)
 Changes in this release:
+- Make sure protected environments can never be cleaned up by pytest-inmanta-lsm fixtures.
 
 # v 3.9.0 (2024-10-29)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -442,7 +442,7 @@ def remote_orchestrator_shared(
             ],
         )
         raise RuntimeError(
-            f"Environment at {settings_url} is protected, it can't be used with pytest-inmanta-lsm."
+            f"Environment is protected, it can't be used with pytest-inmanta-lsm: {settings_url}"
         )
 
     # no need to do anything if this version of inmanta does not support v2 modules

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -437,6 +437,8 @@ def remote_orchestrator_shared(
                         "state.Settings.tab": "Configuration",
                     },
                 ),  # query
+                # Highlight the setting on the web console page
+                # https://web.dev/articles/text-fragments#start
                 ":~:text=protected_environment",  # fragment
             ],
         )

--- a/src/pytest_inmanta_lsm/plugin.py
+++ b/src/pytest_inmanta_lsm/plugin.py
@@ -15,16 +15,17 @@ import shutil
 import tempfile
 import textwrap
 import time
+import urllib.parse
 import uuid
 from typing import Any, Dict, Generator, Iterator, Optional, Tuple, Union
 from uuid import UUID
-import urllib.parse
 
 import pkg_resources
 import pytest
 import pytest_inmanta.plugin
 import pytest_inmanta.test_parameter
 from inmanta import module
+from inmanta.data import model
 from packaging import version
 from pytest_inmanta.plugin import Project
 from pytest_inmanta.test_parameter import (
@@ -70,8 +71,6 @@ from pytest_inmanta_lsm.remote_orchestrator import (
     OrchestratorEnvironment,
     RemoteOrchestrator,
 )
-
-from inmanta.data import model
 
 try:
     # make sure that lsm methods are loaded
@@ -441,9 +440,7 @@ def remote_orchestrator_shared(
                 ":~:text=protected_environment",  # fragment
             ],
         )
-        raise RuntimeError(
-            f"Environment is protected, it can't be used with pytest-inmanta-lsm: {settings_url}"
-        )
+        raise RuntimeError(f"Environment is protected, it can't be used with pytest-inmanta-lsm: {settings_url}")
 
     # no need to do anything if this version of inmanta does not support v2 modules
     if hasattr(module, "ModuleV2"):


### PR DESCRIPTION
# Description

Make sure pytest-inmanta-lsm fixtures can never cleanup a protected environment and report it clearly when the developer tries to do it.  It was already not possible because the orchestrator prevents it via the api, but the filesystem cleanup would still be possible and the reported error wouldn't be as explicit.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
