### PR TITLE
Issue/workaround multi version lsm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 3.11.0 (?)
 Changes in this release:
 - Fix rsync for iso8 project, add .env-py* to excluded paths.
+- Explicitly reject multi-version lsm requests in mock, waiting for proper support.
 
 # v 3.10.0 (2024-11-26)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -538,6 +538,7 @@ class LsmProject:
         This is not supported yet by LsmProject mock.  Until then, behaves as if the
         api didn't know this endpoint (lsm module will fallback to the legacy one).
         """
+        # https://github.com/inmanta/pytest-inmanta-lsm/issues/467
         return inmanta.protocol.common.Result(
             code=500,
             result={

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -360,6 +360,13 @@ class LsmProject:
 
         self.monkeypatch.setattr(
             inmanta_plugins.lsm.global_cache.get_client(),
+            "lsm_service_catalog_get_entity_version",
+            self.lsm_service_catalog_get_entity_version,
+            raising=False,
+        )
+
+        self.monkeypatch.setattr(
+            inmanta_plugins.lsm.global_cache.get_client(),
             "lsm_service_catalog_get_entity",
             self.lsm_service_catalog_get_entity,
             raising=False,
@@ -520,6 +527,23 @@ class LsmProject:
         service.last_updated = datetime.datetime.now()
 
         return inmanta.protocol.common.Result(code=200, result={})
+    
+    def lsm_service_catalog_get_entity_version(
+        self,
+        tid: uuid.UUID,
+        service_entity: str,
+        version: int,
+    ) -> inmanta.protocol.common.Result:
+        """
+        This is not supported yet by LsmProject mock.  Until then, behaves as if the
+        api didn't know this endpoint (lsm module will fallback to the legacy one).
+        """
+        return inmanta.protocol.common.Result(
+            code=500,
+            result={
+                "message": "LsmProject doesn't support multi-version lsm yet",
+            },
+        )
 
     def lsm_service_catalog_get_entity(
         self,

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -527,7 +527,7 @@ class LsmProject:
         service.last_updated = datetime.datetime.now()
 
         return inmanta.protocol.common.Result(code=200, result={})
-    
+
     def lsm_service_catalog_get_entity_version(
         self,
         tid: uuid.UUID,


### PR DESCRIPTION
# Description

Patch leak in mocked lsm, that would reach whatever is listening on localhost:8888 when using multi-version aware lsm module.  Proper support will come with https://github.com/inmanta/pytest-inmanta-lsm/issues/467

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
