### PR TITLE
Extend LsmProject mock to support multi version lsm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v 3.12.0 (?)
 Changes in this release:
 - Automatically resolve postgres container version required by product container image.
+- Added support for multi-version lsm on the mock.
 
 # v 3.11.0 (2024-12-13)
 Changes in this release:

--- a/examples/test-multi-version/.gitignore
+++ b/examples/test-multi-version/.gitignore
@@ -1,0 +1,5 @@
+inmanta_plugins/**/__pycache__
+tests/**/__pycache__
+*.orig
+.vscode
+.pytest_cache

--- a/examples/test-multi-version/MANIFEST.in
+++ b/examples/test-multi-version/MANIFEST.in
@@ -1,0 +1,5 @@
+include inmanta_plugins/test_partial/setup.cfg
+include inmanta_plugins/test_partial/py.typed
+recursive-include inmanta_plugins/test_partial/model *.cf
+graft inmanta_plugins/test_partial/files
+graft inmanta_plugins/test_partial/templates

--- a/examples/test-multi-version/README.md
+++ b/examples/test-multi-version/README.md
@@ -1,0 +1,1 @@
+# test_multi_version Module

--- a/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
+++ b/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
@@ -1,7 +1,7 @@
 """
-    Pytest Inmanta LSM
+Pytest Inmanta LSM
 
-    :copyright: 2025 Inmanta
-    :contact: code@inmanta.com
-    :license: Inmanta EULA
+:copyright: 2025 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
 """

--- a/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
+++ b/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
@@ -1,0 +1,7 @@
+"""
+    Pytest Inmanta LSM
+
+    :copyright: 2025 Inmanta
+    :contact: code@inmanta.com
+    :license: Inmanta EULA
+"""

--- a/examples/test-multi-version/model/_init.cf
+++ b/examples/test-multi-version/model/_init.cf
@@ -1,0 +1,125 @@
+"""
+    Pytest Inmanta LSM
+
+    :copyright: 2025 Inmanta
+    :contact: code@inmanta.com
+    :license: Inmanta EULA
+"""
+
+import lsm
+import lsm::fsm
+import std::testing
+
+entity Parent extends lsm::ServiceEntity:
+    string name
+    string description
+    string description__description="The description of the parent."
+    lsm::attribute_modifier description__modifier="rw+"
+end
+
+index Parent(instance_id)
+
+
+entity Child extends lsm::ServiceEntity:
+    string name
+end
+
+Child.parent_entity [1] lsm::__service__, lsm::__rwplus__ Parent
+
+index Child(instance_id)
+index Child(parent_entity, name)
+
+
+# Add relations between service entity bindings
+
+binding_parent = lsm::ServiceBinding(
+    default_version=0,
+    service_entity_name="parent",
+    versions=[
+        lsm::ServiceBindingVersion(
+            service_entity="test_multi_version::Parent",
+            lifecycle=lsm::fsm::simple_with_delete_validate,
+            service_identity="name",
+            version=0
+        )
+    ]
+)
+
+binding_child = lsm::ServiceBinding(
+    default_version=0,
+    service_entity_name="child",
+    versions=[
+        lsm::ServiceBindingVersion(
+            service_entity="test_multi_version::Child",
+            lifecycle=lsm::fsm::simple_with_delete_validate,
+            owner = lsm::get_service_binding_version(binding_parent, 0),
+            relation_to_owner = "parent_entity",
+            service_identity="name",
+            version=0,
+        ),
+    ]
+)
+
+for instance in lsm::all(binding_parent):
+    Parent(
+        instance_id = instance["id"],
+        entity_binding = lsm::get_service_binding_version(binding_parent, 0),
+        **instance["attributes"],
+    )
+end
+
+for instance in lsm::all(binding_child):
+    Child(
+        instance_id = instance["id"],
+        entity_binding = lsm::get_service_binding_version(binding_child, 0),
+        name = instance["attributes"]["name"],
+        parent_entity = Parent[instance_id=instance["attributes"]["parent_entity"]]
+    )
+end
+
+
+implement Parent using parents
+implement Child using parents
+
+
+implementation tracer for lsm::ServiceEntity:
+    tester = std::testing::NullResource(
+        name=self.name,
+    )
+    self.resources += tester
+    self.owned_resources += tester
+end
+
+implement Parent using tracer
+implement Child using tracer
+
+
+
+entity SecondTree extends lsm::ServiceEntity:
+""" A service to have a second, disjoint tree of services, one level high in this case """
+     string name
+end
+
+index SecondTree(instance_id)
+
+binding_second = lsm::ServiceBinding(
+    default_version=0,
+    service_entity_name="second_parent",
+    versions=[
+        lsm::ServiceBindingVersion(
+            service_entity="test_multi_version::SecondTree",
+            lifecycle=lsm::fsm::simple_with_delete_validate,
+            service_identity="name",
+        )
+    ]
+)
+
+for instance in lsm::all(binding_second):
+    SecondTree(
+        instance_id = instance["id"],
+        entity_binding = lsm::get_service_binding_version(binding_second, 0),
+        **instance["attributes"],
+    )
+end
+implement SecondTree using parents
+implement SecondTree using tracer

--- a/examples/test-multi-version/model/_init.cf
+++ b/examples/test-multi-version/model/_init.cf
@@ -74,7 +74,7 @@ binding_child = lsm::ServiceBinding(
     ]
 )
 
-for instance in lsm::all(binding_parent):
+for instance in lsm::all(binding_parent, include_purged_embedded_entities=true):
     Parent(
         instance_id = instance["id"],
         entity_binding = lsm::get_service_binding_version(binding_parent, 0),
@@ -82,7 +82,7 @@ for instance in lsm::all(binding_parent):
     )
 end
 
-for instance in lsm::all(binding_child):
+for instance in lsm::all(binding_child, include_purged_embedded_entities=true):
     Child(
         instance_id = instance["id"],
         entity_binding = lsm::get_service_binding_version(binding_child, 0),
@@ -112,6 +112,9 @@ implement Child using tracer
 entity SecondTree extends lsm::ServiceEntity:
 """ A service to have a second, disjoint tree of services, one level high in this case """
      string name
+     string description
+    string description__description="The description of the child."
+    lsm::attribute_modifier description__modifier="rw+"
 end
 
 index SecondTree(instance_id)
@@ -133,8 +136,11 @@ for instance in lsm::all(binding_second, include_purged_embedded_entities=true):
         instance_id = instance["id"],
         entity_binding = lsm::get_service_binding_version(binding_second, 0),
         name=instance["attributes"]["name"],
-        other = SecondTreeChild(child_name = instance["attributes"]["name"])
+        description=instance["attributes"]["description"]
     )
+    if instance["attributes"]["description"] == "test":
+        parent.other = SecondTreeChild(child_name = instance["attributes"]["name"])
+    end
 end
 implement SecondTree using parents
 implement SecondTree using tracer

--- a/examples/test-multi-version/model/_init.cf
+++ b/examples/test-multi-version/model/_init.cf
@@ -24,6 +24,12 @@ entity Child extends lsm::ServiceEntity:
     string name
 end
 
+entity ChildV2 extends Child:
+    string description
+    string description__description="The description of the child."
+    lsm::attribute_modifier description__modifier="rw+"
+end
+
 Child.parent_entity [1] lsm::__service__, lsm::__rwplus__ Parent
 
 index Child(instance_id)
@@ -46,7 +52,7 @@ binding_parent = lsm::ServiceBinding(
 )
 
 binding_child = lsm::ServiceBinding(
-    default_version=0,
+    default_version=1,
     service_entity_name="child",
     versions=[
         lsm::ServiceBindingVersion(
@@ -56,6 +62,14 @@ binding_child = lsm::ServiceBinding(
             relation_to_owner = "parent_entity",
             service_identity="name",
             version=0,
+        ),
+        lsm::ServiceBindingVersion(
+            service_entity="test_multi_version::ChildV2",
+            lifecycle=lsm::fsm::simple_with_delete_validate,
+            owner = lsm::get_service_binding_version(binding_parent, 0),
+            relation_to_owner = "parent_entity",
+            service_identity="name",
+            version=1,
         ),
     ]
 )
@@ -114,12 +128,22 @@ binding_second = lsm::ServiceBinding(
     ]
 )
 
-for instance in lsm::all(binding_second):
-    SecondTree(
+for instance in lsm::all(binding_second, include_purged_embedded_entities=true):
+    parent = SecondTree(
         instance_id = instance["id"],
         entity_binding = lsm::get_service_binding_version(binding_second, 0),
-        **instance["attributes"],
+        name=instance["attributes"]["name"],
+        other = SecondTreeChild(child_name = instance["attributes"]["name"])
     )
 end
 implement SecondTree using parents
 implement SecondTree using tracer
+
+entity SecondTreeChild extends lsm::EmbeddedEntity:
+    string child_name
+end
+
+index SecondTreeChild(_parent, child_name)
+
+implement SecondTreeChild using std::none
+SecondTree.other [0:1] -- SecondTreeChild._parent [1]

--- a/examples/test-multi-version/pyproject.toml
+++ b/examples/test-multi-version/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/examples/test-multi-version/setup.cfg
+++ b/examples/test-multi-version/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = inmanta-module-test-multi-version
+version = 0.0.1
+description = Test module that supports multi-version lsm.
+author = Inmanta
+author_email = code@inmanta.com
+license = ASL 2.0
+copyright = 2025 Inmanta
+
+[options]
+zip_safe=False
+include_package_data=True
+packages=find_namespace:
+install_requires =
+    inmanta-module-std>=3.1
+    inmanta-module-lsm>=2.19
+
+[options.packages.find]
+include = inmanta_plugins*

--- a/examples/test-multi-version/tests/test_basics.py
+++ b/examples/test-multi-version/tests/test_basics.py
@@ -91,7 +91,7 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
     # Create a child service without providing a service_entity_version
     service = lsm_project.create_service(
         service_entity_name="second_parent",
-        attributes={"name": "second_tree"},
+        attributes={"name": "second_tree", "description": "test"},
         # With auto_transfer=True, we follow the first auto transfers of the service's
         # lifecycle, triggering a compile (validating compile when appropriate) for
         # each state we meets.
@@ -106,3 +106,13 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
     # Move to the up state
     service.state = "up"
     lsm_project.compile(service_id=service.id)
+
+    new_attributes = copy.deepcopy(service.active_attributes)
+    new_attributes["description"] = "my-other-description"
+    lsm_project.update_service(
+        service_id=service.id,
+        attributes=new_attributes,
+        auto_transfer=True,
+    )
+    # Assert that the service has been updated and is now in update_inprogress state
+    assert parent_service.state == "update_inprogress"

--- a/examples/test-multi-version/tests/test_basics.py
+++ b/examples/test-multi-version/tests/test_basics.py
@@ -1,9 +1,9 @@
 """
-    Pytest Inmanta LSM
+Pytest Inmanta LSM
 
-    :copyright: 2022 Inmanta
-    :contact: code@inmanta.com
-    :license: Inmanta EULA
+:copyright: 2025 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
 """
 
 import copy

--- a/examples/test-multi-version/tests/test_basics.py
+++ b/examples/test-multi-version/tests/test_basics.py
@@ -18,7 +18,7 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
     # Create a service.  This will add it to our inventory, in its initial state
     # (as defined in the lifecycle), and fill in any default attributes we didn't
     # provide.
-    service = lsm_project.create_service(
+    parent_service = lsm_project.create_service(
         service_entity_name="parent",
         attributes={"name": "parent", "description": "my-description"},
         # With auto_transfer=True, we follow the first auto transfers of the service's
@@ -27,6 +27,38 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
         auto_transfer=True,
     )
 
+    # Assert that the service has been created and is now in creating state
+    assert parent_service.state == "creating"
+
+    # Do a second compile, in the non-validating creating state
+    lsm_project.compile(service_id=parent_service.id)
+
+    # Move to the up state
+    parent_service.state = "up"
+    lsm_project.compile(service_id=parent_service.id)
+
+    # Trigger an update on our service from the up state.  Change the vlan id
+    new_attributes = copy.deepcopy(parent_service.active_attributes)
+    new_attributes["description"] = "my-other-description"
+    lsm_project.update_service(
+        service_id=parent_service.id,
+        attributes=new_attributes,
+        auto_transfer=True,
+    )
+
+    # Assert that the service has been updated and is now in update_inprogress state
+    assert parent_service.state == "update_inprogress"
+
+    # Create a child service with service_entity_version set to a non-default version
+    service = lsm_project.create_service(
+        service_entity_name="child",
+        attributes={"name": "child", "parent_entity": parent_service.id},
+        service_entity_version=0,
+        # With auto_transfer=True, we follow the first auto transfers of the service's
+        # lifecycle, triggering a compile (validating compile when appropriate) for
+        # each state we meets.
+        auto_transfer=True,
+    )
     # Assert that the service has been created and is now in creating state
     assert service.state == "creating"
 
@@ -37,14 +69,40 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
     service.state = "up"
     lsm_project.compile(service_id=service.id)
 
-    # Trigger an update on our service from the up state.  Change the vlan id
-    new_attributes = copy.deepcopy(service.active_attributes)
-    new_attributes["description"] = "my-other-description"
-    lsm_project.update_service(
-        service_id=service.id,
-        attributes=new_attributes,
+    # Create a child service without providing a service_entity_version
+    service = lsm_project.create_service(
+        service_entity_name="child",
+        attributes={"name": "childV2", "description": "another_child", "parent_entity": parent_service.id},
+        # With auto_transfer=True, we follow the first auto transfers of the service's
+        # lifecycle, triggering a compile (validating compile when appropriate) for
+        # each state we meets.
         auto_transfer=True,
     )
+    # Assert that the service has been created and is now in creating state
+    assert service.state == "creating"
 
-    # Assert that the service has been updated and is now in update_inprogress state
-    assert service.state == "update_inprogress"
+    # Do a second compile, in the non-validating creating state
+    lsm_project.compile(service_id=service.id)
+
+    # Move to the up state
+    service.state = "up"
+    lsm_project.compile(service_id=service.id)
+
+    # Create a child service without providing a service_entity_version
+    service = lsm_project.create_service(
+        service_entity_name="second_parent",
+        attributes={"name": "second_tree"},
+        # With auto_transfer=True, we follow the first auto transfers of the service's
+        # lifecycle, triggering a compile (validating compile when appropriate) for
+        # each state we meets.
+        auto_transfer=True,
+    )
+    # Assert that the service has been created and is now in creating state
+    assert service.state == "creating"
+
+    # Do a second compile, in the non-validating creating state
+    lsm_project.compile(service_id=service.id)
+
+    # Move to the up state
+    service.state = "up"
+    lsm_project.compile(service_id=service.id)

--- a/examples/test-multi-version/tests/test_basics.py
+++ b/examples/test-multi-version/tests/test_basics.py
@@ -1,0 +1,50 @@
+"""
+    Pytest Inmanta LSM
+
+    :copyright: 2022 Inmanta
+    :contact: code@inmanta.com
+    :license: Inmanta EULA
+"""
+
+import copy
+
+import pytest_inmanta_lsm.lsm_project
+
+
+def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
+    # Export the service entities
+    lsm_project.export_service_entities("import test_multi_version")
+
+    # Create a service.  This will add it to our inventory, in its initial state
+    # (as defined in the lifecycle), and fill in any default attributes we didn't
+    # provide.
+    service = lsm_project.create_service(
+        service_entity_name="parent",
+        attributes={"name": "parent", "description": "my-description"},
+        # With auto_transfer=True, we follow the first auto transfers of the service's
+        # lifecycle, triggering a compile (validating compile when appropriate) for
+        # each state we meets.
+        auto_transfer=True,
+    )
+
+    # Assert that the service has been created and is now in creating state
+    assert service.state == "creating"
+
+    # Do a second compile, in the non-validating creating state
+    lsm_project.compile(service_id=service.id)
+
+    # Move to the up state
+    service.state = "up"
+    lsm_project.compile(service_id=service.id)
+
+    # Trigger an update on our service from the up state.  Change the vlan id
+    new_attributes = copy.deepcopy(service.active_attributes)
+    new_attributes["description"] = "my-other-description"
+    lsm_project.update_service(
+        service_id=service.id,
+        attributes=new_attributes,
+        auto_transfer=True,
+    )
+
+    # Assert that the service has been updated and is now in update_inprogress state
+    assert service.state == "update_inprogress"

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -884,10 +884,10 @@ class LsmProject:
         # The `desired_state_version` field has only recently been added to inmanta_lsm.
         # This ensures compatibility with older versions of the orchestrator.
         try:
-            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore
+            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore[arg-type]
         except AttributeError:
             service_instance_attributes.pop("desired_state_version", None)
-            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore
+            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore[arg-type]
 
         # Add the service to our inventory
         self.add_service(service)

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -362,12 +362,12 @@ class LsmProject:
             raising=False,
         )
 
-        # self.monkeypatch.setattr(
-        #     inmanta_plugins.lsm.global_cache.get_client(),
-        #     "lsm_service_catalog_get_entity_version",
-        #     self.lsm_service_catalog_get_entity_version,
-        #     raising=False,
-        # )
+        self.monkeypatch.setattr(
+            inmanta_plugins.lsm.global_cache.get_client(),
+            "lsm_service_catalog_get_entity_version",
+            self.lsm_service_catalog_get_entity_version,
+            raising=False,
+        )
 
         self.monkeypatch.setattr(
             inmanta_plugins.lsm.global_cache.get_client(),
@@ -553,16 +553,9 @@ class LsmProject:
         version: int,
     ) -> inmanta.protocol.common.Result:
         """
-        This is a mock for the lsm api, this method is called ???
+        This is a mock for the lsm api, this method is called when `include_purged_embedded_entities` is set to true
+        when unrolling a service entity binding.
         """
-        raise Exception
-        # TODO: Not sure where this came up yet
-        return inmanta.protocol.common.Result(
-            code=500,
-            result={
-                "message": "LsmProject doesn't support multi-version lsm yet",
-            },
-        )
         assert (
             self.service_entities is not None
         ), "The service catalog has not been initialized, please call self.export_service_entities"

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -555,6 +555,7 @@ class LsmProject:
         """
         This is a mock for the lsm api, this method is called ???
         """
+        raise Exception
         # TODO: Not sure where this came up yet
         return inmanta.protocol.common.Result(
             code=500,
@@ -730,7 +731,6 @@ class LsmProject:
                 types,
                 False,
             )
-        print(self.service_entities)
 
     def get_service(self, service_id: typing.Union[uuid.UUID, str]) -> inmanta_lsm.model.ServiceInstance:
         """

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -858,13 +858,14 @@ class LsmProject:
         """
         # Resolve the initial state for our service and resolve attributes defaults
         service_entity = self.get_service_entity(service_entity_name, service_entity_version)
+        assert self.service_entities
 
         # Create the service instance object
         service_instance_attributes = {
             "id": service_id or uuid.uuid4(),
             "environment": uuid.UUID(self.environment),
             "service_entity": service_entity_name,
-            "service_entity_version": self.service_entities[service_entity_name, service_entity_version].version,
+            "service_entity_version": self.service_entities[(service_entity_name, service_entity_version)].version,
             "version": 1,
             "desired_state_version": 1,
             "config": {},
@@ -883,10 +884,10 @@ class LsmProject:
         # The `desired_state_version` field has only recently been added to inmanta_lsm.
         # This ensures compatibility with older versions of the orchestrator.
         try:
-            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)
+            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore
         except AttributeError:
             service_instance_attributes.pop("desired_state_version", None)
-            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)
+            service = inmanta_lsm.model.ServiceInstance(**service_instance_attributes)  # type: ignore
 
         # Add the service to our inventory
         self.add_service(service)

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -572,7 +572,7 @@ class LsmProject:
         )
 
     def lsm_service_catalog_get_entity(
-        self, tid: uuid.UUID, service_entity: str, version: typing.Optional[int] = None
+        self, tid: uuid.UUID, service_entity: str, version: int | None = None
     ) -> inmanta.protocol.common.Result:
         """
         This is a mock for the lsm api, this method is called during export of the
@@ -735,9 +735,7 @@ class LsmProject:
 
         return self.services[str(service_id)]
 
-    def get_service_entity(
-        self, service_entity_name: str, version: typing.Optional[int] = None
-    ) -> inmanta_lsm.model.ServiceEntity:
+    def get_service_entity(self, service_entity_name: str, version: int | None = None) -> inmanta_lsm.model.ServiceEntity:
         """
         Get the service entity with the given name from our service catalog.  If no such service
         entity exists, raise a LookupError.  If the service catalog has not been exported yet,
@@ -836,7 +834,7 @@ class LsmProject:
         service_entity_name: str,
         attributes: dict,
         *,
-        service_entity_version: typing.Optional[int] = None,
+        service_entity_version: int | None = None,
         auto_transfer: bool = True,
         service_id: typing.Optional[uuid.UUID] = None,
     ) -> inmanta_lsm.model.ServiceInstance:

--- a/tests/test_multi_version.py
+++ b/tests/test_multi_version.py
@@ -1,0 +1,44 @@
+"""
+    Pytest Inmanta LSM
+
+    :copyright: 2025 Inmanta
+    :contact: code@inmanta.com
+    :license: Inmanta EULA
+"""
+
+from collections import abc
+
+import pytest
+import utils
+from inmanta import env
+
+
+@pytest.fixture(scope="function")
+def module_venv(testdir: pytest.Testdir, pytestconfig: pytest.Config) -> abc.Iterator[env.VirtualEnv]:
+    """
+    Yields a Python environment with test_partial installed in it.
+    """
+    module_dir = testdir.copy_example("test-multi-version")
+    with utils.module_v2_venv(module_dir) as venv:
+        yield venv
+
+
+@pytest.fixture(scope="function")
+def module_venv_active(
+    deactive_venv: None,
+    module_venv: env.VirtualEnv,
+) -> abc.Iterator[env.VirtualEnv]:
+    """
+    Activates a Python environment with test_partial installed in it for the currently running process.
+    """
+    with utils.activate_venv(module_venv) as venv:
+        yield venv
+
+
+def test_basic_example(testdir, module_venv_active):
+    """Make sure that our plugin works."""
+
+    utils.add_version_constraint_to_project(testdir.tmpdir)
+
+    result = testdir.runpytest("tests/test_basics.py")
+    result.assert_outcomes(passed=1)

--- a/tests/test_multi_version.py
+++ b/tests/test_multi_version.py
@@ -1,9 +1,9 @@
 """
-    Pytest Inmanta LSM
+Pytest Inmanta LSM
 
-    :copyright: 2025 Inmanta
-    :contact: code@inmanta.com
-    :license: Inmanta EULA
+:copyright: 2025 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
 """
 
 from collections import abc


### PR DESCRIPTION
# Description

Added support for multi version lsm on the lsm project mock.
The original ticket mentioned this endpoint `lsm_service_catalog_get_entity_version`. But I believe that it was only reachable because of a bug that I have since solved on lsm. It is still techically reachable so I've fixed it.

Also mocked the `lsm_service_catalog_update_entity_versions` endpoint which is used with the multi version bindings


closes #467 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
