### PR TITLE
Don't reload config

### DIFF
--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -286,7 +286,6 @@ class RemoteOrchestrator:
         """
         Setup the config required to make it possible for the client to reach the orchestrator.
         """
-        inmanta_config.Config.load_config()
         inmanta_config.Config.set("config", "environment", str(self.environment))
 
         for section in ["compiler_rest_transport", "client_rest_transport"]:


### PR DESCRIPTION
# Description

The Config.set(...) call get_instance() which is a non-destructive way of loading the config, this should make it easier to use the rmeote orchestrator with other config-modifying fixtures

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
