### PR TITLE
Issue/fix token auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - Addressed memory leak caused by LsmProject monkeypatching.
 - Add more explicit LsmProject.exporting_compile and LsmProject.validating_compile methods.
+- Fix usage of pytest-inmanta-lsm with an orchestrator that has authentication enabled.
 
 # v 3.12.0 (2025-04-09)
 Changes in this release:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@ inmanta-dev-dependencies==2.158.0
 types-PyYAML
 types-requests
 types-setuptools
+types-toml

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -15,7 +15,6 @@ import subprocess
 import typing
 import urllib.parse
 import uuid
-import toml
 from pprint import pformat
 from uuid import UUID
 
@@ -26,6 +25,7 @@ import inmanta.module
 import inmanta.protocol.endpoints
 import pydantic
 import requests
+import toml
 from inmanta.agent import config as inmanta_config
 from inmanta.protocol.common import Result
 from packaging.version import Version

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -253,12 +253,12 @@ class RemoteOrchestrator:
         # remote api might be different (i.e. podman exec -i <container-name> vs curl <container-ip>)
         self.remote_host = remote_host if remote_host is not None else host
 
+        # Setting up the client when the config is loaded
+        self.setup_config()
+
         # Build the client once, it loads the config on every call
         self.client = inmanta.protocol.endpoints.SyncClient("client")
         self.async_client = inmanta.protocol.endpoints.Client("client")
-
-        # Setting up the client when the config is loaded
-        self.setup_config()
 
         # Save the version of the remote orchestrator server
         self._server_version: typing.Optional[Version] = None

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -254,7 +254,7 @@ class RemoteOrchestrator:
         # remote api might be different (i.e. podman exec -i <container-name> vs curl <container-ip>)
         self.remote_host = remote_host if remote_host is not None else host
 
-        # Setting up the client when the config is loaded
+        # Setting up the client configuration before constructing and using the clients
         self.setup_config()
 
         # Build the client once, it loads the config on every call


### PR DESCRIPTION
# Description

Fix support for orchestrators with authentication enabled:
- Setup client config before constructing clients
- Persist client token in local inmanta config file to sync it to the remote orchestrator

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
