### PR TITLE
Issue/fix sync execute scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes in this release:
 - Addressed memory leak caused by LsmProject monkeypatching.
 - Add more explicit LsmProject.exporting_compile and LsmProject.validating_compile methods.
 - Fix usage of pytest-inmanta-lsm with an orchestrator that has authentication enabled.
+- Fix usage of sync_execute_scenarios with async functions which return a non-None value.
 
 # v 3.12.0 (2025-04-09)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/util.py
+++ b/src/pytest_inmanta_lsm/util.py
@@ -68,7 +68,7 @@ async def execute_scenarios(
     )
 
     # Filter the list of exceptions
-    exceptions = [exc for exc in exceptions if exc is not None]
+    exceptions = [exc for exc in exceptions if isinstance(exc, Exception)]
 
     if len(exceptions) == 0:
         # No exception to raise


### PR DESCRIPTION
# Description

- Fix usage of sync_execute_scenarios with async functions which return a non-None value.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
