### PR TITLE
Issue/improve service export testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
 - All to configure `PIP_CONSTRAINT` environment variable on the remote host during project install, using the `--pip-constraint` pytest option.
 - Fix format of inmanta config saved in the project synced to remote orchestrator.
+- Improve export_service_entities functionality in LsmProject and RemoteOrchestrator to mimic the lsm extension better.
 
 # v 3.13.0 (2025-06-19)
 Changes in this release:

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -35,6 +35,12 @@ INMANTA_LSM_MODULE_NOT_LOADED = (
     "    - If you are using v2 modules: make sure the inmanta-module-lsm is installed in your venv."
 )
 
+try:
+    from inmanta_lsm.const import ENV_NO_INSTANCES
+except ImportError:
+    # Ensure backwards compatibility with older versions of the inmanta-lsm extensions.
+    ENV_NO_INSTANCES = "lsm_no_instances"
+
 # Try to import from inmanta.util.dict_path, if not available, fall back to the deprecated inmanta_lsm.dict_path
 try:
     from inmanta.util import dict_path
@@ -632,7 +638,8 @@ class LsmProject:
 
         # Make a compile without any services in the catalog
         with pytest.MonkeyPatch.context() as m:
-            m.setattr(self, "services", {})
+            # https://github.com/inmanta/inmanta-lsm/blob/f6b9c7b8a861b233c682349e36d478f0afcb89b8/src/inmanta_lsm/service_catalog.py#L705
+            m.setenv(ENV_NO_INSTANCES, "true")
             self.project.compile(model, no_dedent=False)
 
         # Get the exporter, it should have been set during the compile

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -941,10 +941,16 @@ class RemoteOrchestrator:
                 "export",
                 "-e",
                 str(self.environment),
+                # https://github.com/inmanta/inmanta-lsm/blob/f6b9c7b8a861b233c682349e36d478f0afcb89b8/src/inmanta_lsm/service_catalog.py#L695
+                # https://github.com/inmanta/inmanta-core/blob/6d77faea6d409eec645e132c2480e6a9d4bc4e1c/src/inmanta/server/services/compilerservice.py#L493
+                "-j",
+                f"/tmp/{self.environment}.json",
                 "--export-plugin",
                 "service_entities_exporter",
             ],
             cwd=str(self.remote_project_path),
+            # https://github.com/inmanta/inmanta-lsm/blob/f6b9c7b8a861b233c682349e36d478f0afcb89b8/src/inmanta_lsm/service_catalog.py#L705
+            env={"lsm_no_instances": "true"},
         )
 
     def wait_for_released(self, version: int | None = None) -> None:


### PR DESCRIPTION
# Description

- Improve export_service_entities functionality in LsmProject and RemoteOrchestrator to mimic the lsm extension better.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
