### PR TITLE
use asyncio.run to execute on an event loop

### DIFF
--- a/src/pytest_inmanta_lsm/remote_service_instance.py
+++ b/src/pytest_inmanta_lsm/remote_service_instance.py
@@ -11,8 +11,6 @@ import logging
 import typing
 import uuid
 
-import inmanta.util
-
 from pytest_inmanta_lsm import remote_orchestrator, remote_service_instance_async
 
 LOGGER = logging.getLogger(__name__)
@@ -62,7 +60,7 @@ class RemoteServiceInstance:
             result = attr(*args, **kwargs)
             if asyncio.iscoroutine(result):
                 # This is a coroutine, we need to execute it in an event loop
-                return inmanta.util.ensure_event_loop().run_until_complete(result)
+                return asyncio.run(result)
             else:
                 # Not a coroutine, the method has been executed successfully, we can
                 # return its result


### PR DESCRIPTION
# Description

I believe this should be equivalent, because if this were called in an async context, it would result in a deadlock anyway. Please be critical.

I discovered an issue with `inmanta.util.ensure_event_loop()`, where it may recreate an event loop if one exists but is not running (because we're in a sync context). So I thought it best to phase it out.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
