### PR TITLE
fix dev tag_build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,6 @@ target-version = 'py311'
 [egg_info]
 # Append a zero at the end as a workaround for setuptools bug (pypa/pip#9446)
 # see https://github.com/pypa/pip/issues/9446
-tag_build = .dev0
+tag_build = dev0
 tag_date = 0
 tag_svn_revision = 0


### PR DESCRIPTION
# Description

The python-package-release tool was broken since it is expecting the 'dev0' string (exact match)

extract from trace:
```
...
Serialized to \'\' /home/hugo/.virtualenvs/irt_313/lib/python3.13/site-packages/bumpversion/versioning/serialization.py:135
Rendering search pattern with context /home/hugo/.virtualenvs/irt_313/lib/python3.13/site-packages/bumpversion/config/models.py:56
No RegEx flag detected. Searching for the default pattern: \'tag_build\\ =\\ dev0\' /home/hugo/.virtualenvs/irt_313/lib/python3.13/site-packages/bumpversion/config/models.py:62
'
...
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
