### PR TITLE
Bump minimal required python version to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## v5.0.0 - ?
+## v4.1.1 - ?
 
-- Bump minimal required python version to 3.12
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v4.1.1 - ?
+## v5.0.0 - ?
 
+- Bump minimal required python version to 3.12
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v4.1.1 - ?
+## v4.2.0 - ?
 
+- Bump minimal required python version to 3.12
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-lsm"
-version = "4.1.1"
+version = "5.0.0"
 description = "Common fixtures used in inmanta LSM related modules"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 keywords = ["pytest", "inmanta", "lsm"]
 authors = [{ name = "Inmanta", email = "code@inmanta.com" }]
@@ -19,7 +19,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Pytest",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Testing",
@@ -49,7 +48,7 @@ pytest_inmanta_lsm = ["py.typed", "resources/*"]
 
 
 [tool.bumpversion]
-current_version = "4.1.1.dev0"
+current_version = "5.0.0.dev0"
 tag = false
 commit = false
 parse = """
@@ -84,7 +83,7 @@ replace = "tag_build = {new_version}"
 
 [tool.black]
 line-length = 128
-target-version = ['py311']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-lsm"
-version = "5.0.0"
+version = "4.1.1"
 description = "Common fixtures used in inmanta LSM related modules"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -48,7 +48,7 @@ pytest_inmanta_lsm = ["py.typed", "resources/*"]
 
 
 [tool.bumpversion]
-current_version = "5.0.0.dev0"
+current_version = "4.1.1.dev0"
 tag = false
 commit = false
 parse = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-lsm"
-version = "4.1.1"
+version = "4.2.0"
 description = "Common fixtures used in inmanta LSM related modules"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -48,7 +48,7 @@ pytest_inmanta_lsm = ["py.typed", "resources/*"]
 
 
 [tool.bumpversion]
-current_version = "4.1.1.dev0"
+current_version = "4.2.0.dev0"
 tag = false
 commit = false
 parse = """


### PR DESCRIPTION
# Description

Similar PR as https://github.com/inmanta/pytest-inmanta-yang/pull/389

This should unblock further bumps of inmanta-dev-dependencies

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
