### PR TITLE
Issue/execute scenarios max concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.2.0 - ?
 
 - Bump minimal required python version to 3.12
+- Add `max_concurrency` parameter to `execute_scenarios` and `sync_execute_scenarios` to cap the number of scenarios running in parallel.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - Bump minimal required python version to 3.12
 - Add `max_concurrency` parameter to `execute_scenarios` and `sync_execute_scenarios` to cap the number of scenarios running in parallel.
 
-
-
-
 ## v4.1.0 - 2026-02-12
 
 - Extend LsmProject and RemoteServiceInstance to support service creation in alternative initial state. (inmanta-lsm>=5.2.0)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Shortcuts for various dev tasks. Based on makefile from pydantic
 .DEFAULT_GOAL := all
-isort = isort src tests examples *.py
-black = black src tests examples *.py
-flake8 = flake8 src tests examples *.py
+isort = isort src tests examples
+black = black src tests examples
+flake8 = flake8 src tests examples
 
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ flake8 = flake8 src tests examples *.py
 
 .PHONY: install
 install:
-	pip install -U setuptools pip
-	pip install -U --upgrade-strategy=eager -r requirements.dev.txt -c requirements.txt -e .
+	UV_CONSTRAINT=${PIP_CONSTRAINT} UV_DEFAULT_INDEX=${PIP_INDEX_URL} uv pip install -U -e . -c requirements.txt -r requirements.dev.txt --pre
 
 .PHONY: format
 format:

--- a/examples/test-partial/tests/test_basics.py
+++ b/examples/test-partial/tests/test_basics.py
@@ -30,9 +30,7 @@ def test_service_instances(
     remote_orchestrator_partial: bool,
 ) -> None:
     # set up project
-    project.compile(
-        textwrap.dedent(
-            """
+    project.compile(textwrap.dedent("""
             import test_partial
             import test_partial::service
             import unittest_lsm
@@ -43,11 +41,7 @@ def test_service_instances(
             end
 
             implement test_partial::UnittestResourceStub using resource
-            """.strip(
-                "\n"
-            )
-        )
-    )
+            """.strip("\n")))
     service: str = "network"
 
     # sync project and export service entities

--- a/examples/test_service/tests/test_deployment_failure.py
+++ b/examples/test_service/tests/test_deployment_failure.py
@@ -16,11 +16,9 @@ def test_full_cycle(project, remote_orchestrator, fail: bool):
     # get connection to remote_orchestrator
     client = remote_orchestrator.client
 
-    project.compile(
-        """
+    project.compile("""
         import test_service
-        """
-    )
+        """)
 
     # sync project and export service entities
     remote_orchestrator.export_service_entities()

--- a/src/pytest_inmanta_lsm/util.py
+++ b/src/pytest_inmanta_lsm/util.py
@@ -31,6 +31,7 @@ async def execute_scenarios(
     *scenarios: collections.abc.Awaitable,
     sequential: bool = False,
     timeout: typing.Optional[float] = None,
+    max_concurrency: int | None = None,
 ) -> None:
     """
     Execute all the given scenarios.  If a scenario fails, raises its exception (after
@@ -41,6 +42,8 @@ async def execute_scenarios(
     :param sequential: Execute all the scenarios sequentially instead of concurrently.
         Defaults to False, can be enabled for debugging purposes, to get cleaner logs.
     :param timeout: A global timeout to set for the execution of all scenarios.
+    :param max_concurrency: The maximum amount of test scenarios that can run in parallel.
+        When more scenarios are provided, they are queued until another scenario is done.
     """
 
     async def execute_sequentially(*scenarios: collections.abc.Awaitable) -> None:
@@ -86,6 +89,7 @@ def sync_execute_scenarios(
     *scenarios: collections.abc.Awaitable,
     sequential: bool = False,
     timeout: typing.Optional[float] = None,
+    max_concurrency: int | None = None,
 ) -> None:
     """
     Execute all the given scenarios.  If a scenario fails, raises its exception (after
@@ -95,6 +99,8 @@ def sync_execute_scenarios(
     :param sequential: Execute all the scenarios sequentially instead of concurrently.
         Defaults to False, can be enabled for debugging purposes, to get cleaner logs.
     :param timeout: A global timeout to set for the execution of all scenarios.
+    :param max_concurrency: The maximum amount of test scenarios that can run in parallel.
+        When more scenarios are provided, they are queued until another scenario is done.
     """
 
-    asyncio.run(execute_scenarios(*scenarios, sequential=sequential, timeout=timeout))
+    asyncio.run(execute_scenarios(*scenarios, sequential=sequential, timeout=timeout, max_concurrency=max_concurrency))

--- a/src/pytest_inmanta_lsm/util.py
+++ b/src/pytest_inmanta_lsm/util.py
@@ -60,6 +60,18 @@ async def execute_scenarios(
         # each scenario, one at a time
         scenarios = (execute_sequentially(*scenarios),)
 
+    if max_concurrency is not None and not sequential:
+        # Cap the number of scenarios running in parallel. The timer for
+        # the per-scenario timeout (if any) only starts once a slot is
+        # acquired, since the wait_for is wrapped inside the semaphore.
+        semaphore = asyncio.Semaphore(max_concurrency)
+
+        async def with_semaphore(scenario: collections.abc.Awaitable) -> object:
+            async with semaphore:
+                return await scenario
+
+        scenarios = tuple(with_semaphore(s) for s in scenarios)
+
     if timeout:
         # If we received a timeout parameter, we make sure each scenario
         # will stop if the timeout is reached

--- a/src/pytest_inmanta_lsm/util.py
+++ b/src/pytest_inmanta_lsm/util.py
@@ -62,8 +62,8 @@ async def execute_scenarios(
 
     if max_concurrency is not None and not sequential:
         # Cap the number of scenarios running in parallel. The timer for
-        # the per-scenario timeout (if any) only starts once a slot is
-        # acquired, since the wait_for is wrapped inside the semaphore.
+        # the per-scenario timeout (if any) starts even before the slot is
+        # acquired, as we want this timeout to be global, not per scenario.
         semaphore = asyncio.Semaphore(max_concurrency)
 
         async def with_semaphore(scenario: collections.abc.Awaitable) -> object:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,60 @@
+"""
+Pytest Inmanta LSM
+
+:copyright: 2026 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
+"""
+
+import asyncio
+
+import pytest
+
+from pytest_inmanta_lsm.util import sync_execute_scenarios
+
+
+def test_execute_scenarios_max_concurrency() -> None:
+    """
+    Verify that max_concurrency caps the number of scenarios running in parallel.
+    """
+    state = {"in_flight": 0, "peak": 0}
+
+    async def scenario() -> None:
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        await asyncio.sleep(0.05)
+        state["in_flight"] -= 1
+
+    max_concurrency = 2
+    sync_execute_scenarios(*(scenario() for _ in range(6)), max_concurrency=max_concurrency)
+    assert state["peak"] == max_concurrency
+
+
+def test_execute_scenarios_no_max_concurrency() -> None:
+    """
+    Verify that without max_concurrency all scenarios run in parallel.
+    """
+    state = {"in_flight": 0, "peak": 0}
+
+    async def scenario() -> None:
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        await asyncio.sleep(0.05)
+        state["in_flight"] -= 1
+
+    n = 5
+    sync_execute_scenarios(*(scenario() for _ in range(n)))
+    assert state["peak"] == n
+
+
+@pytest.mark.parametrize("max_concurrency", [None, 1, 3])
+def test_execute_scenarios_propagates_exception(max_concurrency: int | None) -> None:
+    """
+    Verify that exceptions still propagate when max_concurrency is set.
+    """
+
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        sync_execute_scenarios(boom(), max_concurrency=max_concurrency)


### PR DESCRIPTION
# Description

- Add `max_concurrency` parameter to `execute_scenarios` and `sync_execute_scenarios` to cap the number of scenarios running in parallel.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
