### PR TITLE
Issue/do not delete state dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump minimal required python version to 3.12
 - Add `max_concurrency` parameter to `execute_scenarios` and `sync_execute_scenarios` to cap the number of scenarios running in parallel.
+- Make sure `RemoteOrchestrator.run_command` doesn't fallback to the access user `HOME` when the `cwd` folder doesn't exist.
 
 ## v4.1.0 - 2026-02-12
 

--- a/src/pytest_inmanta_lsm/remote_orchestrator.py
+++ b/src/pytest_inmanta_lsm/remote_orchestrator.py
@@ -576,7 +576,7 @@ class RemoteOrchestrator:
         if cwd is not None:
             # Pretend that the command is a shell, and add a cd ... prefix to it
             shell = True
-            cmd = shlex.join(["cd", cwd]) + "; " + cmd
+            cmd = shlex.join(["cd", cwd]) + " && " + cmd
 
         if shell:
             # The command we received should be run in a shell


### PR DESCRIPTION
# Description

- `run_command` didn't check result of `cd` command.  This means that if cd fails, the command might be executed in the wrong folder.  Instead, fail if the target directory doesn't exist.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
