### PR TITLE
Add RemoteOrder to drive services through the order API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v4.2.1 - ?
+## v4.3.0 - ?
+
+- Add `RemoteOrder` (and its async variant `remote_order_async.RemoteOrder`) to create, update and delete service instances through the orchestrator order API.
 
 
 ## v4.2.0 - 2026-04-29

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,7 @@ stub:
 	stubgen --include-docstrings src/pytest_inmanta_lsm/remote_service_instance_async.py
 	sed -i -e 's/async def/def/g' out/pytest_inmanta_lsm/remote_service_instance_async.pyi
 	mv out/pytest_inmanta_lsm/remote_service_instance_async.pyi src/pytest_inmanta_lsm/remote_service_instance.pyi
+	stubgen --include-docstrings src/pytest_inmanta_lsm/remote_order_async.py
+	sed -i -e 's/async def/def/g' out/pytest_inmanta_lsm/remote_order_async.pyi
+	mv out/pytest_inmanta_lsm/remote_order_async.pyi src/pytest_inmanta_lsm/remote_order.pyi
 	$(MAKE) format

--- a/README.md
+++ b/README.md
@@ -295,6 +295,27 @@ def test_order(project: plugin.Project, remote_orchestrator: remote_orchestrator
 As with `RemoteServiceInstance`, an `async` variant (`remote_order_async.RemoteOrder`) is available, which can be combined with `util.sync_execute_scenarios` to drive multiple orders concurrently.
 > source: [test_quickstart.py::test_order_full_cycle](./examples/quickstart/tests/test_quickstart.py)
 
+Instead of building the order items yourself, you can also let the order build them from `RemoteServiceInstance` objects, with the `add_create_instance`, `add_update_instance` and `add_delete_instance` helpers.  The same `RemoteServiceInstance` objects can then be used to follow each service instance through its lifecycle.
+
+```python
+    order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    instance = remote_service_instance.RemoteServiceInstance(
+        remote_orchestrator=remote_orchestrator,
+        service_entity_name=SERVICE_NAME,
+    )
+    order.add_create_instance(
+        instance,
+        {
+            "router_ip": "10.1.9.17",
+            "interface_name": "eth1",
+            "address": "10.0.0.254/24",
+            "vlan_id": 14,
+        },
+    )
+    order.create(wait_for_state=inmanta_lsm.order.model.OrderState.success, timeout=60)
+```
+> source: [test_quickstart.py::test_order_full_cycle](./examples/quickstart/tests/test_quickstart.py)
+
 
 ### Second case: mocking the lsm api
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,60 @@ def test_full_cycle(project: plugin.Project, remote_orchestrator: remote_orchest
 ```
 > source: [test_quickstart.py::test_full_cycle](./examples/quickstart/tests/test_quickstart.py)
 
+#### Driving services through the order API
+
+Instead of managing a single service instance at a time with `RemoteServiceInstance`, you can use the orchestrator's order API to create, update and delete one or more service instances in a single atomic order.  The `RemoteOrder` class (and its async counterpart `remote_order_async.RemoteOrder`) wraps this API and lets you wait for the resulting order to reach a terminal state.  Just like `RemoteServiceInstance`, it relies on the typed objects exposed by `inmanta_lsm` (`inmanta_lsm.order.model`).
+
+```python
+def test_order(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:
+    # setup project
+    project.compile("import quickstart")
+
+    # sync project and export service entities
+    remote_orchestrator.export_service_entities()
+
+    # Pick an id for the instance we are going to manage through the order api
+    instance_id = uuid.uuid4()
+
+    # Create an instance through the synchronous order api, and wait for the order to complete
+    order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    service_order = order.create(
+        [
+            inmanta_lsm.order.model.CreateWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.create,
+                attributes={
+                    "router_ip": "10.1.9.17",
+                    "interface_name": "eth1",
+                    "address": "10.0.0.254/24",
+                    "vlan_id": 14,
+                },
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+    assert service_order.status.state == inmanta_lsm.order.model.OrderState.success
+
+    # Clean up the instance through the order api
+    order.create(
+        [
+            inmanta_lsm.order.model.DeleteWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.delete,
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+```
+> source: [test_quickstart.py::test_order_sync](./examples/quickstart/tests/test_quickstart.py)
+
+As with `RemoteServiceInstance`, an `async` variant (`remote_order_async.RemoteOrder`) is available, which can be combined with `util.sync_execute_scenarios` to drive multiple orders concurrently.
+> source: [test_quickstart.py::test_order_full_cycle](./examples/quickstart/tests/test_quickstart.py)
+
 
 ### Second case: mocking the lsm api
 

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -12,6 +12,7 @@ import time
 import uuid
 
 import inmanta_lsm.model
+import inmanta_lsm.order.model
 import pytest
 from pytest_inmanta import plugin
 
@@ -19,6 +20,8 @@ import pytest_inmanta_lsm.lsm_project
 from pytest_inmanta_lsm import (
     load_generator,
     remote_orchestrator,
+    remote_order,
+    remote_order_async,
     remote_service_instance,
     remote_service_instance_async,
     util,
@@ -257,6 +260,148 @@ def test_transient_state(project: plugin.Project, remote_orchestrator: remote_or
 
     # Delete the instance
     instance.delete(wait_for_state="terminated", timeout=60)
+
+
+async def order_full_cycle(
+    remote_orchestrator: remote_orchestrator.RemoteOrchestrator,
+    router_ip: str,
+    interface_name: str,
+    address: str,
+    vlan_id: int,
+    vlan_id_update: int,
+) -> None:
+    # Pick an id for the instance we are going to manage through the order api
+    instance_id = uuid.uuid4()
+
+    # Create the instance using the order api, and wait for the order to complete
+    create_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    await create_order.create(
+        [
+            inmanta_lsm.order.model.CreateWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.create,
+                attributes={
+                    "router_ip": router_ip,
+                    "interface_name": interface_name,
+                    "address": address,
+                    "vlan_id": vlan_id,
+                },
+            ),
+        ],
+        description="Create a vlan-assignment service",
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+    # Update the vlan id using the order api
+    update_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    await update_order.create(
+        [
+            inmanta_lsm.order.model.UpdateWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.update,
+                edits=[
+                    inmanta_lsm.model.PatchCallEdit(
+                        edit_id=str(uuid.uuid4()),
+                        operation=inmanta_lsm.model.EditOperation.replace,
+                        target="vlan_id",
+                        value=vlan_id_update,
+                    ),
+                ],
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+    # Delete the instance using the order api
+    delete_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    await delete_order.create(
+        [
+            inmanta_lsm.order.model.DeleteWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.delete,
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+
+def test_order_full_cycle(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:
+    # setup project
+    project.compile("import quickstart")
+
+    # sync project and export service entities
+    remote_orchestrator.export_service_entities()
+
+    # Deploy multiple services concurrently, each through its own set of orders
+    first_service = order_full_cycle(
+        remote_orchestrator=remote_orchestrator,
+        router_ip="10.1.9.17",
+        interface_name="eth1",
+        address="10.0.0.254/24",
+        vlan_id=14,
+        vlan_id_update=42,
+    )
+    another_service = order_full_cycle(
+        remote_orchestrator=remote_orchestrator,
+        router_ip="10.1.9.18",
+        interface_name="eth2",
+        address="10.0.0.253/24",
+        vlan_id=15,
+        vlan_id_update=52,
+    )
+    util.sync_execute_scenarios(first_service, another_service)
+
+
+def test_order_sync(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:
+    # setup project
+    project.compile("import quickstart")
+
+    # sync project and export service entities
+    remote_orchestrator.export_service_entities()
+
+    # Create an instance through the synchronous order api
+    instance_id = uuid.uuid4()
+    order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    service_order = order.create(
+        [
+            inmanta_lsm.order.model.CreateWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.create,
+                attributes={
+                    "router_ip": "10.1.9.19",
+                    "interface_name": "eth3",
+                    "address": "10.0.0.252/24",
+                    "vlan_id": 16,
+                },
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+    # Assert that the order reached the success state and manages our instance
+    assert service_order.status.state == inmanta_lsm.order.model.OrderState.success
+    assert {item.instance_id for item in service_order.service_order_items} == {instance_id}
+
+    # Clean up the instance through the order api
+    order.create(
+        [
+            inmanta_lsm.order.model.DeleteWritableServiceOrderItem(
+                instance_id=instance_id,
+                service_entity=SERVICE_NAME,
+                action=inmanta_lsm.order.model.OrderItemAction.delete,
+            ),
+        ],
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
 
 
 def test_model_legacy(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -365,10 +365,11 @@ def test_order_sync(project: plugin.Project, remote_orchestrator: remote_orchest
     # sync project and export service entities
     remote_orchestrator.export_service_entities()
 
-    # Create an instance through the synchronous order api
+    # Create an instance through the synchronous order api.  Each order is a one-shot
+    # object, so we use a dedicated RemoteOrder for the create and for the delete.
     instance_id = uuid.uuid4()
-    order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
-    service_order = order.create(
+    create_order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    service_order = create_order.create(
         [
             inmanta_lsm.order.model.CreateWritableServiceOrderItem(
                 instance_id=instance_id,
@@ -391,7 +392,8 @@ def test_order_sync(project: plugin.Project, remote_orchestrator: remote_orchest
     assert {item.instance_id for item in service_order.service_order_items} == {instance_id}
 
     # Clean up the instance through the order api
-    order.create(
+    delete_order = remote_order.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    delete_order.create(
         [
             inmanta_lsm.order.model.DeleteWritableServiceOrderItem(
                 instance_id=instance_id,

--- a/examples/quickstart/tests/test_quickstart.py
+++ b/examples/quickstart/tests/test_quickstart.py
@@ -331,6 +331,60 @@ async def order_full_cycle(
     )
 
 
+async def order_full_cycle_with_instances(
+    remote_orchestrator: remote_orchestrator.RemoteOrchestrator,
+    *attributes: dict[str, object],
+) -> None:
+    # Create a service instance object for each set of attributes, and add their
+    # creation to a single order.  The order builds the order items itself, and
+    # assigns an id to each instance when it is added to the order.
+    create_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    instances = []
+    for service_attributes in attributes:
+        instance = remote_service_instance_async.RemoteServiceInstance(
+            remote_orchestrator=remote_orchestrator,
+            service_entity_name=SERVICE_NAME,
+        )
+        create_order.add_create_instance(instance, service_attributes)
+        instances.append(instance)
+
+    # Create the order on the remote orchestrator, all the service instances are
+    # created together, in a single api call
+    await create_order.create(
+        description="Create vlan-assignment services",
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+    # Update the vlan id of every instance, in a single order as well
+    update_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    for instance, service_attributes in zip(instances, attributes):
+        update_order.add_update_instance(
+            instance,
+            [
+                inmanta_lsm.model.PatchCallEdit(
+                    edit_id=str(uuid.uuid4()),
+                    operation=inmanta_lsm.model.EditOperation.replace,
+                    target="vlan_id",
+                    value=service_attributes["vlan_id"] + 100,
+                ),
+            ],
+        )
+    await update_order.create(
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+    # Delete all the instances, together in a single order
+    delete_order = remote_order_async.RemoteOrder(remote_orchestrator=remote_orchestrator)
+    for instance in instances:
+        delete_order.add_delete_instance(instance)
+    await delete_order.create(
+        wait_for_state=inmanta_lsm.order.model.OrderState.success,
+        timeout=60,
+    )
+
+
 def test_order_full_cycle(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:
     # setup project
     project.compile("import quickstart")
@@ -355,7 +409,26 @@ def test_order_full_cycle(project: plugin.Project, remote_orchestrator: remote_o
         vlan_id=15,
         vlan_id_update=52,
     )
-    util.sync_execute_scenarios(first_service, another_service)
+
+    # Drive two more services together, sharing a single order for each step of
+    # their lifecycle, using the helpers that build the order items from service
+    # instance objects
+    ordered_together = order_full_cycle_with_instances(
+        remote_orchestrator,
+        {
+            "router_ip": "10.1.9.20",
+            "interface_name": "eth3",
+            "address": "10.0.0.251/24",
+            "vlan_id": 17,
+        },
+        {
+            "router_ip": "10.1.9.21",
+            "interface_name": "eth4",
+            "address": "10.0.0.250/24",
+            "vlan_id": 18,
+        },
+    )
+    util.sync_execute_scenarios(first_service, another_service, ordered_together)
 
 
 def test_order_sync(project: plugin.Project, remote_orchestrator: remote_orchestrator.RemoteOrchestrator) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-lsm"
-version = "4.2.1"
+version = "4.3.0"
 description = "Common fixtures used in inmanta LSM related modules"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -48,7 +48,7 @@ pytest_inmanta_lsm = ["py.typed", "resources/*"]
 
 
 [tool.bumpversion]
-current_version = "4.2.1.dev0"
+current_version = "4.3.0.dev0"
 tag = false
 commit = false
 parse = """

--- a/src/pytest_inmanta_lsm/__init__.py
+++ b/src/pytest_inmanta_lsm/__init__.py
@@ -24,9 +24,9 @@ def retry_limited(fun: Callable[[], bool], timeout: int, *, retry_interval: floa
     :param retry_interval: How long to wait for between each run of the function, in seconds.
     :raise AssertionError: in case when timeout has been reached
     """
-    start = time.time()
+    start = time.monotonic()
     result = fun()
-    while time.time() - start < timeout and not result:
+    while time.monotonic() - start < timeout and not result:
         time.sleep(retry_interval)
         result = fun()
 

--- a/src/pytest_inmanta_lsm/remote_order.py
+++ b/src/pytest_inmanta_lsm/remote_order.py
@@ -1,0 +1,78 @@
+"""
+Pytest Inmanta LSM
+
+:copyright: 2026 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
+"""
+
+import asyncio
+import logging
+import typing
+import uuid
+
+from pytest_inmanta_lsm import remote_orchestrator, remote_order_async
+from pytest_inmanta_lsm.remote_order_async import (  # noqa: F401
+    BadOrderStateError,
+    OrderStateTimeoutError,
+    RemoteOrderError,
+    format_failures,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RemoteOrder:
+    """
+    Helper class to use the RemoteOrder in a non-async context.  It will proxy all getattr/setattr
+    operations to the async order it wraps, and return a sync method when the method accessed
+    on the wrapped object is a coroutine.
+    """
+
+    def __init__(
+        self,
+        remote_orchestrator: remote_orchestrator.RemoteOrchestrator,
+        order_id: typing.Optional[uuid.UUID] = None,
+    ) -> None:
+        """
+        :param remote_orchestrator: remote_orchestrator to create the order on
+        :param order_id: manually choose the id of the order
+        """
+        self.async_order = remote_order_async.RemoteOrder(
+            remote_orchestrator=remote_orchestrator,
+            order_id=order_id,
+        )
+
+    def __getattr__(self, __name: str) -> object:
+        """
+        When getting an attribute, proxy it to the wrapped order.  If the attribute
+        is a coroutine, return a wrapper that allows to execute it synchronously.
+        """
+        attr = getattr(self.async_order, __name)
+
+        if not callable(attr):
+            # This is a simple attribute, we return it as is
+            return attr
+
+        # The attribute is a method, we should return a wrapper that calls it, and handles
+        # it correctly when the value returned is a coroutine.
+        def sync_call(*args: object, **kwargs: object) -> object:
+            result = attr(*args, **kwargs)
+            if asyncio.iscoroutine(result):
+                # This is a coroutine, we need to execute it in an event loop
+                return asyncio.run(result)
+            else:
+                # Not a coroutine, the method has been executed successfully, we can
+                # return its result
+                return result
+
+        return sync_call
+
+    def __setattr__(self, __name: str, __value: object) -> None:
+        """
+        Set an attribute on the wrapped order.
+        """
+        if __name != "async_order":
+            return setattr(self.async_order, __name, __value)
+        else:
+            super().__setattr__(__name, __value)

--- a/src/pytest_inmanta_lsm/remote_order.py
+++ b/src/pytest_inmanta_lsm/remote_order.py
@@ -16,6 +16,7 @@ from pytest_inmanta_lsm.remote_order_async import (  # noqa: F401
     BadOrderStateError,
     OrderStateTimeoutError,
     RemoteOrderError,
+    ServiceInstanceTypes,
     format_failures,
 )
 

--- a/src/pytest_inmanta_lsm/remote_order.pyi
+++ b/src/pytest_inmanta_lsm/remote_order.pyi
@@ -1,0 +1,84 @@
+import typing
+import uuid
+from _typeshed import Incomplete
+from inmanta_lsm.order import model as order_model
+from pytest_inmanta_lsm import remote_orchestrator as remote_orchestrator
+
+LOGGER: Incomplete
+T = typing.TypeVar('T')
+
+class RemoteOrderError(RuntimeError, typing.Generic[T]):
+    """
+    Base exception for error raised by a remote order.
+    """
+    instance: Incomplete
+    def __init__(self, instance: T, *args: object) -> None: ...
+
+class BadOrderStateError(RemoteOrderError[T]):
+    """
+    This error is raised when an order goes into a state that is considered to be a bad one.
+    """
+    bad_states: Incomplete
+    order: Incomplete
+    def __init__(self, instance: T, bad_states: typing.Collection[order_model.OrderState], order: order_model.ServiceOrder, *args: object) -> None: ...
+
+class OrderStateTimeoutError(RemoteOrderError[T], TimeoutError):
+    """
+    This error is raised when we hit a timeout, while waiting for an order to reach a target state.
+    """
+    target_state: Incomplete
+    timeout: Incomplete
+    last_state: Incomplete
+    def __init__(self, instance: T, target_state: order_model.OrderState, timeout: float, last_state: order_model.OrderState | None, *args: object) -> None: ...
+
+def format_failures(order: order_model.ServiceOrder) -> str:
+    """
+    Build a human readable summary of all the failing order items of the given order.
+
+    :param order: The order for which we want to display the failing items.
+    """
+
+class RemoteOrder:
+    DEFAULT_TIMEOUT: float
+    RETRY_INTERVAL: float
+    ALL_BAD_STATES: list[order_model.OrderState]
+    remote_orchestrator: Incomplete
+    def __init__(self, remote_orchestrator: remote_orchestrator.RemoteOrchestrator, order_id: uuid.UUID | None = None) -> None:
+        """
+        :param remote_orchestrator: remote_orchestrator to create the order on
+        :param order_id: manually choose the id of the order
+        """
+    @property
+    def order_id(self) -> uuid.UUID: ...
+    def get(self) -> order_model.ServiceOrder:
+        """
+        Get the current order in its current state, and return it as a ServiceOrder object.
+        """
+    def wait_for_state(self, target_state: order_model.OrderState = ..., *, bad_states: typing.Collection[order_model.OrderState] | None = None, timeout: float | None = None) -> order_model.ServiceOrder:
+        """
+        Wait for this order to reach the desired target state.  Returns a ServiceOrder object
+        that is in the state that was waited for.
+
+        :param target_state: The state we want to wait our order to reach.
+        :param bad_states: A collection of bad state that should interrupt the waiting process and
+            trigger a BadOrderStateError.  If set to None, default to self.ALL_BAD_STATES with the
+            target_state removed from it.
+        :param timeout: The time, in seconds, after which we should stop waiting and raise an
+            OrderStateTimeoutError.  If set to None, uses the DEFAULT_TIMEOUT attribute of the object.
+        :raises BadOrderStateError: If the order went into a bad state
+        :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
+        """
+    def create(self, service_order_items: list[order_model.WritableServiceOrderItemTypes], *, description: str = '', wait_for_state: order_model.OrderState | None = ..., bad_states: typing.Collection[order_model.OrderState] | None = None, timeout: float | None = None) -> order_model.ServiceOrder:
+        """
+        Create the order and wait for it to go into `wait_for_state`.
+
+        :param service_order_items: The list of order items (create/update/delete) that make up this order.
+        :param description: An optional description to attach to the order.
+        :param wait_for_state: wait for this state to be reached, if set to None, returns directly, and
+            doesn't wait.  Defaults to OrderState.success.
+        :param bad_states: stop waiting and fail if any of these states are reached.  If set to None,
+            default to self.ALL_BAD_STATES with the target_state removed from it.
+        :param timeout: how long can we wait for the order to achieve given state (in seconds)
+        :raises BadOrderStateError: If the order went into a bad state
+        :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
+        """

--- a/src/pytest_inmanta_lsm/remote_order.pyi
+++ b/src/pytest_inmanta_lsm/remote_order.pyi
@@ -1,16 +1,25 @@
 import typing
 import uuid
+
 from _typeshed import Incomplete
+from inmanta_lsm import model as model
 from inmanta_lsm.order import model as order_model
+
 from pytest_inmanta_lsm import remote_orchestrator as remote_orchestrator
+from pytest_inmanta_lsm import remote_service_instance as remote_service_instance
+from pytest_inmanta_lsm import (
+    remote_service_instance_async as remote_service_instance_async,
+)
 
 LOGGER: Incomplete
-T = typing.TypeVar('T')
+T = typing.TypeVar("T")
+ServiceInstanceTypes = remote_service_instance_async.RemoteServiceInstance | remote_service_instance.RemoteServiceInstance
 
 class RemoteOrderError(RuntimeError, typing.Generic[T]):
     """
     Base exception for error raised by a remote order.
     """
+
     instance: Incomplete
     def __init__(self, instance: T, *args: object) -> None: ...
 
@@ -18,18 +27,29 @@ class BadOrderStateError(RemoteOrderError[T]):
     """
     This error is raised when an order goes into a state that is considered to be a bad one.
     """
+
     bad_states: Incomplete
     order: Incomplete
-    def __init__(self, instance: T, bad_states: typing.Collection[order_model.OrderState], order: order_model.ServiceOrder, *args: object) -> None: ...
+    def __init__(
+        self, instance: T, bad_states: typing.Collection[order_model.OrderState], order: order_model.ServiceOrder, *args: object
+    ) -> None: ...
 
 class OrderStateTimeoutError(RemoteOrderError[T], TimeoutError):
     """
     This error is raised when we hit a timeout, while waiting for an order to reach a target state.
     """
+
     target_state: Incomplete
     timeout: Incomplete
     last_state: Incomplete
-    def __init__(self, instance: T, target_state: order_model.OrderState, timeout: float, last_state: order_model.OrderState | None, *args: object) -> None: ...
+    def __init__(
+        self,
+        instance: T,
+        target_state: order_model.OrderState,
+        timeout: float,
+        last_state: order_model.OrderState | None,
+        *args: object,
+    ) -> None: ...
 
 def format_failures(order: order_model.ServiceOrder) -> str:
     """
@@ -39,6 +59,24 @@ def format_failures(order: order_model.ServiceOrder) -> str:
     """
 
 class RemoteOrder:
+    """
+    Helper class to create, update or delete service instances on a remote orchestrator
+    through the order api (POST /lsm/v2/order) instead of the service inventory api.
+    The order items can either be built by the caller and passed to `create`, or be
+    built by the order itself, from RemoteServiceInstance objects, with the
+    `add_create_instance`, `add_update_instance` and `add_delete_instance` helpers.
+    The same RemoteServiceInstance objects can then be used to follow each service
+    instance through its lifecycle.
+
+    .. code-block:: python
+
+        order = remote_order_async.RemoteOrder(remote_orchestrator)
+        instance = remote_service_instance_async.RemoteServiceInstance(remote_orchestrator, "vlan-assignment")
+        order.add_create_instance(instance, {"vlan_id": 14, ...})
+        await order.create(timeout=60)
+
+    """
+
     DEFAULT_TIMEOUT: float
     RETRY_INTERVAL: float
     ALL_BAD_STATES: list[order_model.OrderState]
@@ -48,13 +86,61 @@ class RemoteOrder:
         :param remote_orchestrator: remote_orchestrator to create the order on
         :param order_id: manually choose the id of the order
         """
+
     @property
     def order_id(self) -> uuid.UUID: ...
+    def add_create_instance(self, service_instance: ServiceInstanceTypes, attributes: dict[str, object]) -> None:
+        """
+        Add the creation of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the service instance will only be created as
+        part of the order execution, once the order has been created.
+
+        If the service instance doesn't have an id yet, one is picked for it: the order
+        api requires the id of the instances it creates to be set on the client side.
+
+        :param service_instance: The service instance to create as part of this order.
+        :param attributes: The attributes of the service instance that should be created.
+        """
+
+    def add_update_instance(self, service_instance: ServiceInstanceTypes, edit: list[model.PatchCallEdit]) -> None:
+        """
+        Add an update of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the update will only be applied as part of
+        the order execution, once the order has been created.
+
+        The order api only supports updating instances of service entities which have
+        strict modifier enforcement enabled.  Beware that an update which doesn't
+        change the desired state of the instance completes without triggering any
+        transfer in the instance lifecycle (and without creating a new version of the
+        instance).
+
+        :param service_instance: The (existing) service instance to update as part of
+            this order.
+        :param edit: The actual edit operations to perform.
+        """
+
+    def add_delete_instance(self, service_instance: ServiceInstanceTypes) -> None:
+        """
+        Add the deletion of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the service instance will only be deleted as
+        part of the order execution, once the order has been created.
+
+        :param service_instance: The (existing) service instance to delete as part of
+            this order.
+        """
+
     def get(self) -> order_model.ServiceOrder:
         """
         Get the current order in its current state, and return it as a ServiceOrder object.
         """
-    def wait_for_state(self, target_state: order_model.OrderState = ..., *, bad_states: typing.Collection[order_model.OrderState] | None = None, timeout: float | None = None) -> order_model.ServiceOrder:
+
+    def wait_for_state(
+        self,
+        target_state: order_model.OrderState = ...,
+        *,
+        bad_states: typing.Collection[order_model.OrderState] | None = None,
+        timeout: float | None = None,
+    ) -> order_model.ServiceOrder:
         """
         Wait for this order to reach the desired target state.  Returns a ServiceOrder object
         that is in the state that was waited for.
@@ -68,11 +154,22 @@ class RemoteOrder:
         :raises BadOrderStateError: If the order went into a bad state
         :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
         """
-    def create(self, service_order_items: list[order_model.WritableServiceOrderItemTypes], *, description: str = '', wait_for_state: order_model.OrderState | None = ..., bad_states: typing.Collection[order_model.OrderState] | None = None, timeout: float | None = None) -> order_model.ServiceOrder:
+
+    def create(
+        self,
+        service_order_items: list[order_model.WritableServiceOrderItemTypes] | None = None,
+        *,
+        description: str = "",
+        wait_for_state: order_model.OrderState | None = ...,
+        bad_states: typing.Collection[order_model.OrderState] | None = None,
+        timeout: float | None = None,
+    ) -> order_model.ServiceOrder:
         """
         Create the order and wait for it to go into `wait_for_state`.
 
-        :param service_order_items: The list of order items (create/update/delete) that make up this order.
+        :param service_order_items: The list of order items (create/update/delete) that make up this
+            order, in addition to the items added with the `add_*_instance` helpers.  Can be left
+            out if the order items have all been added with those helpers.
         :param description: An optional description to attach to the order.
         :param wait_for_state: wait for this state to be reached, if set to None, returns directly, and
             doesn't wait.  Defaults to OrderState.success.

--- a/src/pytest_inmanta_lsm/remote_order_async.py
+++ b/src/pytest_inmanta_lsm/remote_order_async.py
@@ -1,0 +1,254 @@
+"""
+Pytest Inmanta LSM
+
+:copyright: 2026 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
+"""
+
+import asyncio
+import logging
+import time
+import typing
+import uuid
+
+import devtools
+from inmanta_lsm.order import model as order_model  # type: ignore
+
+from pytest_inmanta_lsm import remote_orchestrator
+
+LOGGER = logging.getLogger(__name__)
+
+
+T = typing.TypeVar("T")
+
+
+class RemoteOrderError(RuntimeError, typing.Generic[T]):
+    """
+    Base exception for error raised by a remote order.
+    """
+
+    def __init__(self, instance: T, *args: object) -> None:
+        super().__init__(*args)
+        self.instance = instance
+
+
+class BadOrderStateError(RemoteOrderError[T]):
+    """
+    This error is raised when an order goes into a state that is considered to be a bad one.
+    """
+
+    def __init__(
+        self,
+        instance: T,
+        bad_states: typing.Collection[order_model.OrderState],
+        order: order_model.ServiceOrder,
+        *args: object,
+    ) -> None:
+        super().__init__(
+            instance,
+            f"Order {order.id} went into bad state {order.status.state} from bad state list: {bad_states}",
+            *args,
+        )
+        self.bad_states = bad_states
+        self.order = order
+
+
+class OrderStateTimeoutError(RemoteOrderError[T], TimeoutError):
+    """
+    This error is raised when we hit a timeout, while waiting for an order to reach a target state.
+    """
+
+    def __init__(
+        self,
+        instance: T,
+        target_state: order_model.OrderState,
+        timeout: float,
+        last_state: typing.Optional[order_model.OrderState],
+        *args: object,
+    ) -> None:
+        msg = f"Timeout of {timeout} seconds reached while waiting for order to go into state {target_state}."
+        if last_state is not None:
+            msg += f"  Current state: {last_state}"
+        super().__init__(
+            instance,
+            msg,
+            *args,
+        )
+        self.target_state = target_state
+        self.timeout = timeout
+        self.last_state = last_state
+
+
+def format_failures(order: order_model.ServiceOrder) -> str:
+    """
+    Build a human readable summary of all the failing order items of the given order.
+
+    :param order: The order for which we want to display the failing items.
+    """
+    failures = {
+        str(item.instance_id): item.status
+        for item in order.service_order_items
+        if item.status.state == order_model.OrderItemState.failed
+    }
+    return str(devtools.debug.format(failures))
+
+
+class RemoteOrder:
+    DEFAULT_TIMEOUT = 600.0
+    RETRY_INTERVAL = 5.0
+
+    # An order is done as soon as it is not in progress anymore.  The only fully
+    # successful terminal state is `success`, all the other terminal states are
+    # considered bad.
+    ALL_BAD_STATES: list[order_model.OrderState] = [
+        order_model.OrderState.failed,
+        order_model.OrderState.partial,
+    ]
+
+    def __init__(
+        self,
+        remote_orchestrator: remote_orchestrator.RemoteOrchestrator,
+        order_id: typing.Optional[uuid.UUID] = None,
+    ) -> None:
+        """
+        :param remote_orchestrator: remote_orchestrator to create the order on
+        :param order_id: manually choose the id of the order
+        """
+        self.remote_orchestrator = remote_orchestrator
+        self._order_id = order_id
+
+    @property
+    def order_id(self) -> uuid.UUID:
+        if self._order_id is None:
+            raise RuntimeError("Order id is unknown, did you call create already?")
+        else:
+            return self._order_id
+
+    async def get(self) -> order_model.ServiceOrder:
+        """
+        Get the current order in its current state, and return it as a ServiceOrder object.
+        """
+        return await self.remote_orchestrator.request(
+            "lsm_order_get",
+            order_model.ServiceOrder,
+            tid=self.remote_orchestrator.environment,
+            order_id=self.order_id,
+        )
+
+    async def wait_for_state(
+        self,
+        target_state: order_model.OrderState = order_model.OrderState.success,
+        *,
+        bad_states: typing.Optional[typing.Collection[order_model.OrderState]] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> order_model.ServiceOrder:
+        """
+        Wait for this order to reach the desired target state.  Returns a ServiceOrder object
+        that is in the state that was waited for.
+
+        :param target_state: The state we want to wait our order to reach.
+        :param bad_states: A collection of bad state that should interrupt the waiting process and
+            trigger a BadOrderStateError.  If set to None, default to self.ALL_BAD_STATES with the
+            target_state removed from it.
+        :param timeout: The time, in seconds, after which we should stop waiting and raise an
+            OrderStateTimeoutError.  If set to None, uses the DEFAULT_TIMEOUT attribute of the object.
+        :raises BadOrderStateError: If the order went into a bad state
+        :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
+        """
+        if timeout is None:
+            timeout = self.DEFAULT_TIMEOUT
+
+        if bad_states is None:
+            bad_states = [state for state in self.ALL_BAD_STATES if state != target_state]
+
+        # Save the start time to know when we should trigger a timeout error
+        start = time.time()
+
+        # Save the last state, for logging purpose, to tell the user every time we meet a new state
+        last_state: typing.Optional[order_model.OrderState] = None
+
+        while True:
+            order = await self.get()
+            state = order.status.state
+
+            if last_state != state:
+                # We reached a new state, log it for the user
+                LOGGER.debug("Order %s moved to state %s", self.order_id, state)
+                last_state = state
+
+            if state == target_state:
+                return order
+
+            if state in bad_states:
+                # We encountered a bad state, print the failing items then quit
+                LOGGER.info(
+                    "Order %s reached bad state %s: \n%s",
+                    self.order_id,
+                    state,
+                    format_failures(order),
+                )
+                raise BadOrderStateError(self, bad_states, order)
+
+            if time.time() - start > timeout:
+                # We reached the timeout, we should stop waiting and raise an exception
+                LOGGER.info(
+                    "Order %s exceeded timeout while waiting for %s, current state is %s.",
+                    self.order_id,
+                    repr(target_state),
+                    repr(state),
+                )
+                raise OrderStateTimeoutError(self, target_state, timeout, last_state)
+
+            # Wait then try again
+            await asyncio.sleep(self.RETRY_INTERVAL)
+
+    async def create(
+        self,
+        service_order_items: list[order_model.WritableServiceOrderItemTypes],
+        *,
+        description: str = "",
+        wait_for_state: typing.Optional[order_model.OrderState] = order_model.OrderState.success,
+        bad_states: typing.Optional[typing.Collection[order_model.OrderState]] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> order_model.ServiceOrder:
+        """
+        Create the order and wait for it to go into `wait_for_state`.
+
+        :param service_order_items: The list of order items (create/update/delete) that make up this order.
+        :param description: An optional description to attach to the order.
+        :param wait_for_state: wait for this state to be reached, if set to None, returns directly, and
+            doesn't wait.  Defaults to OrderState.success.
+        :param bad_states: stop waiting and fail if any of these states are reached.  If set to None,
+            default to self.ALL_BAD_STATES with the target_state removed from it.
+        :param timeout: how long can we wait for the order to achieve given state (in seconds)
+        :raises BadOrderStateError: If the order went into a bad state
+        :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
+        """
+        LOGGER.info(
+            "Creating new order with %d item(s): %s",
+            len(service_order_items),
+            devtools.debug.format(service_order_items),
+        )
+        order = await self.remote_orchestrator.request(
+            "lsm_order_create",
+            order_model.ServiceOrder,
+            tid=self.remote_orchestrator.environment,
+            service_order_items=service_order_items,
+            id=self._order_id,
+            description=description,
+        )
+
+        # Save the order id for later
+        self._order_id = order.id
+        LOGGER.info("Created order has ID %s", self.order_id)
+
+        if wait_for_state is not None:
+            # Wait for our order to reach the target state
+            return await self.wait_for_state(
+                target_state=wait_for_state,
+                bad_states=bad_states,
+                timeout=timeout,
+            )
+        else:
+            return order

--- a/src/pytest_inmanta_lsm/remote_order_async.py
+++ b/src/pytest_inmanta_lsm/remote_order_async.py
@@ -13,14 +13,29 @@ import typing
 import uuid
 
 import devtools
+from inmanta_lsm import model  # type: ignore
 from inmanta_lsm.order import model as order_model  # type: ignore
 
-from pytest_inmanta_lsm import remote_orchestrator
+from pytest_inmanta_lsm import (
+    remote_orchestrator,
+    remote_service_instance,
+    remote_service_instance_async,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
 T = typing.TypeVar("T")
+
+
+ServiceInstanceTypes = typing.Union[
+    remote_service_instance_async.RemoteServiceInstance,
+    remote_service_instance.RemoteServiceInstance,
+]
+"""
+Both flavors (async and sync) of the RemoteServiceInstance class can be part of
+an order.
+"""
 
 
 class RemoteOrderError(RuntimeError, typing.Generic[T]):
@@ -95,6 +110,24 @@ def format_failures(order: order_model.ServiceOrder) -> str:
 
 
 class RemoteOrder:
+    """
+    Helper class to create, update or delete service instances on a remote orchestrator
+    through the order api (POST /lsm/v2/order) instead of the service inventory api.
+    The order items can either be built by the caller and passed to `create`, or be
+    built by the order itself, from RemoteServiceInstance objects, with the
+    `add_create_instance`, `add_update_instance` and `add_delete_instance` helpers.
+    The same RemoteServiceInstance objects can then be used to follow each service
+    instance through its lifecycle.
+
+    .. code-block:: python
+
+        order = remote_order_async.RemoteOrder(remote_orchestrator)
+        instance = remote_service_instance_async.RemoteServiceInstance(remote_orchestrator, "vlan-assignment")
+        order.add_create_instance(instance, {"vlan_id": 14, ...})
+        await order.create(timeout=60)
+
+    """
+
     DEFAULT_TIMEOUT = 600.0
     RETRY_INTERVAL = 5.0
 
@@ -117,6 +150,8 @@ class RemoteOrder:
         """
         self.remote_orchestrator = remote_orchestrator
         self._order_id = order_id
+        self._items: list[order_model.WritableServiceOrderItemTypes] = []
+        self._created = False
 
     @property
     def order_id(self) -> uuid.UUID:
@@ -124,6 +159,103 @@ class RemoteOrder:
             raise RuntimeError("Order id is unknown, did you call create already?")
         else:
             return self._order_id
+
+    def add_create_instance(
+        self,
+        service_instance: ServiceInstanceTypes,
+        attributes: dict[str, object],
+    ) -> None:
+        """
+        Add the creation of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the service instance will only be created as
+        part of the order execution, once the order has been created.
+
+        If the service instance doesn't have an id yet, one is picked for it: the order
+        api requires the id of the instances it creates to be set on the client side.
+
+        :param service_instance: The service instance to create as part of this order.
+        :param attributes: The attributes of the service instance that should be created.
+        """
+        if self._created:
+            raise RuntimeError("No item can be added to the order anymore, it has already been created")
+
+        if getattr(service_instance, "_instance_id", None) is None:
+            # The order api requires the id of the created instance to be picked on the
+            # client side, assign an id to the instance if it doesn't have any yet.  Use
+            # getattr/setattr as the private attribute is not part of the type stub of
+            # the sync flavor of the service instance class.
+            setattr(service_instance, "_instance_id", uuid.uuid4())
+
+        self._items.append(
+            # Only pass the required fields to the order item, to stay compatible with
+            # versions of inmanta-lsm in which the optional fields don't all exist.  The
+            # type stubs of inmanta-lsm don't expose the default values of those optional
+            # fields, hence the ignored call-arg error.  The attributes parameter is kept
+            # as a plain dict for the caller's convenience, hence the ignored arg-type error.
+            order_model.CreateWritableServiceOrderItem(  # type: ignore[call-arg]
+                instance_id=service_instance.instance_id,
+                service_entity=service_instance.service_entity_name,
+                action=order_model.OrderItemAction.create,
+                attributes=attributes,  # type: ignore[arg-type]
+            )
+        )
+
+    def add_update_instance(
+        self,
+        service_instance: ServiceInstanceTypes,
+        edit: list[model.PatchCallEdit],
+    ) -> None:
+        """
+        Add an update of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the update will only be applied as part of
+        the order execution, once the order has been created.
+
+        The order api only supports updating instances of service entities which have
+        strict modifier enforcement enabled.  Beware that an update which doesn't
+        change the desired state of the instance completes without triggering any
+        transfer in the instance lifecycle (and without creating a new version of the
+        instance).
+
+        :param service_instance: The (existing) service instance to update as part of
+            this order.
+        :param edit: The actual edit operations to perform.
+        """
+        if self._created:
+            raise RuntimeError("No item can be added to the order anymore, it has already been created")
+
+        self._items.append(
+            # cf. add_create_instance for the reason behind the ignored call-arg error
+            order_model.UpdateWritableServiceOrderItem(  # type: ignore[call-arg]
+                instance_id=service_instance.instance_id,
+                service_entity=service_instance.service_entity_name,
+                action=order_model.OrderItemAction.update,
+                edits=edit,
+            )
+        )
+
+    def add_delete_instance(
+        self,
+        service_instance: ServiceInstanceTypes,
+    ) -> None:
+        """
+        Add the deletion of the given service instance to this order.  This doesn't send
+        anything to the orchestrator yet, the service instance will only be deleted as
+        part of the order execution, once the order has been created.
+
+        :param service_instance: The (existing) service instance to delete as part of
+            this order.
+        """
+        if self._created:
+            raise RuntimeError("No item can be added to the order anymore, it has already been created")
+
+        self._items.append(
+            # cf. add_create_instance for the reason behind the ignored call-arg error
+            order_model.DeleteWritableServiceOrderItem(  # type: ignore[call-arg]
+                instance_id=service_instance.instance_id,
+                service_entity=service_instance.service_entity_name,
+                action=order_model.OrderItemAction.delete,
+            )
+        )
 
     async def get(self) -> order_model.ServiceOrder:
         """
@@ -205,7 +337,7 @@ class RemoteOrder:
 
     async def create(
         self,
-        service_order_items: list[order_model.WritableServiceOrderItemTypes],
+        service_order_items: typing.Optional[list[order_model.WritableServiceOrderItemTypes]] = None,
         *,
         description: str = "",
         wait_for_state: typing.Optional[order_model.OrderState] = order_model.OrderState.success,
@@ -215,7 +347,9 @@ class RemoteOrder:
         """
         Create the order and wait for it to go into `wait_for_state`.
 
-        :param service_order_items: The list of order items (create/update/delete) that make up this order.
+        :param service_order_items: The list of order items (create/update/delete) that make up this
+            order, in addition to the items added with the `add_*_instance` helpers.  Can be left
+            out if the order items have all been added with those helpers.
         :param description: An optional description to attach to the order.
         :param wait_for_state: wait for this state to be reached, if set to None, returns directly, and
             doesn't wait.  Defaults to OrderState.success.
@@ -225,22 +359,30 @@ class RemoteOrder:
         :raises BadOrderStateError: If the order went into a bad state
         :raises OrderStateTimeoutError: If the timeout is reached while waiting for the desired state
         """
+        if self._created:
+            raise RuntimeError("The order has already been created")
+
+        items = [*self._items, *(service_order_items if service_order_items is not None else [])]
+        if not items:
+            raise ValueError("The order doesn't contain any items")
+
         LOGGER.info(
             "Creating new order with %d item(s): %s",
-            len(service_order_items),
-            devtools.debug.format(service_order_items),
+            len(items),
+            devtools.debug.format(items),
         )
         order = await self.remote_orchestrator.request(
             "lsm_order_create",
             order_model.ServiceOrder,
             tid=self.remote_orchestrator.environment,
-            service_order_items=service_order_items,
+            service_order_items=items,
             id=self._order_id,
             description=description,
         )
 
         # Save the order id for later
         self._order_id = order.id
+        self._created = True
         LOGGER.info("Created order has ID %s", self.order_id)
 
         if wait_for_state is not None:

--- a/src/pytest_inmanta_lsm/remote_order_async.py
+++ b/src/pytest_inmanta_lsm/remote_order_async.py
@@ -162,8 +162,9 @@ class RemoteOrder:
         if bad_states is None:
             bad_states = [state for state in self.ALL_BAD_STATES if state != target_state]
 
-        # Save the start time to know when we should trigger a timeout error
-        start = time.time()
+        # Save the start time to know when we should trigger a timeout error.  Use a
+        # monotonic clock so we are not affected by changes to the system clock.
+        start = time.monotonic()
 
         # Save the last state, for logging purpose, to tell the user every time we meet a new state
         last_state: typing.Optional[order_model.OrderState] = None
@@ -190,7 +191,7 @@ class RemoteOrder:
                 )
                 raise BadOrderStateError(self, bad_states, order)
 
-            if time.time() - start > timeout:
+            if time.monotonic() - start > timeout:
                 # We reached the timeout, we should stop waiting and raise an exception
                 LOGGER.info(
                     "Order %s exceeded timeout while waiting for %s, current state is %s.",

--- a/src/pytest_inmanta_lsm/remote_service_instance_async.py
+++ b/src/pytest_inmanta_lsm/remote_service_instance_async.py
@@ -301,8 +301,9 @@ class RemoteServiceInstance:
             # Check if both the version and the state match
             return log.version == target_version and log.state == target_state
 
-        # Save the start time to know when we should trigger a timeout error
-        start = time.time()
+        # Save the start time to know when we should trigger a timeout error.  Use a
+        # monotonic clock so we are not affected by changes to the system clock.
+        start = time.monotonic()
 
         # Save the last state, for logging purpose, to tell the user every time we meet a new state
         last_state: typing.Optional[str] = None
@@ -348,7 +349,7 @@ class RemoteServiceInstance:
                 # Save the current version
                 last_version = log.version
 
-            if time.time() - start > timeout:
+            if time.monotonic() - start > timeout:
                 # We reached the timeout, we should stop waiting and raise an exception
                 diagnosis = await self.diagnose(version=log.version)
                 LOGGER.info(

--- a/src/pytest_inmanta_lsm/wait_for_state.py
+++ b/src/pytest_inmanta_lsm/wait_for_state.py
@@ -124,7 +124,7 @@ class WaitForState(object):
         """
 
         LOGGER.info(f"Waiting for {self.name} to go to one of {desired_states}")
-        start_time = time.time()
+        start_time = time.monotonic()
 
         previous_state: State = State(
             name="default",
@@ -180,7 +180,7 @@ class WaitForState(object):
                         )
                         raise BadStateError(instance, bad_states, state)
 
-            if time.time() - start_time > timeout:
+            if time.monotonic() - start_time > timeout:
                 LOGGER.info(
                     self.__compose_error_msg_with_bad_state_error(
                         (

--- a/tests/test_examples_quickstart.py
+++ b/tests/test_examples_quickstart.py
@@ -62,4 +62,4 @@ def test_basic_example(testdir: pytest.Testdir, module_venv_active: env.VirtualE
     utils.add_version_constraint_to_project(testdir.tmpdir)
 
     result = testdir.runpytest("tests/test_quickstart.py", *args)
-    result.assert_outcomes(passed=8)
+    result.assert_outcomes(passed=10)


### PR DESCRIPTION
# Description

Add sync and async `RemoteOrder` classes, mirroring `RemoteServiceInstance`, that wrap the orchestrator order API (`lsm_order_create` / `lsm_order_get`) using the typed objects from `inmanta_lsm.order.model`. They let a test create/update/delete one or more service instances in a single atomic order and wait for the order to reach a terminal state.

- `remote_order_async.RemoteOrder`: async class with `create`, `get`, `wait_for_state`, and the `RemoteOrderError` / `BadOrderStateError` / `OrderStateTimeoutError` exceptions.
- `remote_order.RemoteOrder`: sync wrapper, same proxy pattern as `remote_service_instance`.
- Generated `.pyi` stub + `Makefile` `stub` target updated.
- Quickstart tests extended (`test_order_full_cycle`, `test_order_sync`) and README documented.

closes *no ticket*

# Self Check:

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
