### PR TITLE
use pip directly for setup_project.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.3.0 - ?
 
+- Install the project synced to the remote orchestrator using `pip` and `inmanta project install` in subprocesses, running the project venv's python interpreter, instead of driving the installation with the inmanta core python api.  This drops support for orchestrators older than iso6.
 - Add `RemoteOrder` (and its async variant `remote_order_async.RemoteOrder`) to create, update and delete service instances through the orchestrator order API.
 - Add opt-in compiler reuse for the `lsm_project` fixture (`--lsm-reuse-compiler` / `INMANTA_LSM_REUSE_COMPILER` / `lsm_reuse_compiler` fixture): parse and type-check the model only once and reuse the typed program for every subsequent compile of that same model, significantly speeding up model tests that perform many compiles. While active, it also disables the redundant on-disk parser cache, removing the cost of writing every module's `.cfc` during the cold compile.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ packages = { find = { include = ["pytest_inmanta_lsm*"], where = ["src"] } }
 [tool.setuptools.package-data]
 pytest_inmanta_lsm = ["py.typed", "resources/*"]
 
+[tool.uv]
+# The venv used in ci is installed with an explicit set of constraints, pinning amongst
+# others the version of inmanta-core.  `uv run` would re-resolve the dependencies of this
+# project, ignoring those constraints, and re-sync the venv with the resolved set.  Marking
+# the project as unmanaged makes `uv run` use the venv as-is.
+managed = false
+
 
 [tool.bumpversion]
 current_version = "4.3.0.dev0"

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -10,11 +10,13 @@ import contextlib
 import logging
 import os
 import pathlib
+import subprocess
 import sys
 from collections import abc
+from itertools import chain
 from typing import List, Optional
 
-from inmanta import env, module
+from inmanta import module
 
 # The project_path has to be provided in env var
 project_path = pathlib.Path(os.environ["PROJECT_PATH"])
@@ -30,9 +32,10 @@ LOGGER = logging.getLogger(project_path.name)
 
 
 @contextlib.contextmanager
-def env_vars(var: abc.Mapping[str, str]) -> abc.Iterator[None]:
+def env_vars(var: abc.Mapping[str, Optional[str]]) -> abc.Iterator[None]:
     """
     Context manager to extend the current environment with one or more environment variables.
+    A value of None means that the variable should be unset.
     """
 
     def set_env(set_var: abc.Mapping[str, Optional[str]]) -> None:
@@ -50,10 +53,6 @@ def env_vars(var: abc.Mapping[str, str]) -> abc.Iterator[None]:
 
 # Create the project object, this is the folder we sent to the orchestrator
 project = module.Project(str(project_path), venv_path=str(project_path / ".env"))
-
-# Make sure the virtual environment is ready
-if not project.is_using_virtual_env():
-    project.use_virtual_env()
 
 v2_modules: List[module.ModuleV2] = []
 # Discover all modules in the libs folder and install the v2 ones
@@ -80,29 +79,46 @@ for dir in (project_path / "libs").iterdir():
     v2_modules.append(mod)
     LOGGER.info(f"Module {mod.name} is v2, we will attempt to install it")
 
+
+# TODO: do we need all this? It's based on inmanta.env, but we are in a simpler context here
+def pip_env_vars() -> abc.Mapping[str, Optional[str]]:
+    """
+    Compute the environment variables that make pip install from the package sources
+    configured on the project.  We call pip ourselves, so core doesn't apply the project's
+    sources for us and we have to configure the pip index ourselves.
+    """
+    # The pip section of the project config is the authoritative package source
+    pip_config = project.metadata.pip
+    return {
+        # Only take the config of this host into account when the project allows it
+        "PIP_CONFIG_FILE": None if pip_config.use_system_config else os.devnull,
+        "PIP_INDEX_URL": pip_config.index_url,
+        "PIP_EXTRA_INDEX_URL": " ".join(pip_config.extra_index_url) or None,
+        "PIP_PRE": None if pip_config.pre is None else str(pip_config.pre),
+        # No index to install from, the dependencies are expected to be installed already
+        "PIP_NO_INDEX": "1" if not pip_config.index_url and not pip_config.use_system_config else None,
+    }
+
+
 # Install all v2 modules in editable mode using the project's configured package sources
 if v2_modules:
     LOGGER.info(f"Installing modules from source: {[mod.name for mod in v2_modules]}")
-    paths = [env.LocalPackagePath(mod.path, editable=True) for mod in v2_modules]
-
-    if hasattr(project.virtualenv, "install_for_config"):
-        # For ISO7
-        project.virtualenv.install_for_config([], project.metadata.pip, paths=paths)
-    else:
-        # Pre ISO7
-        # plain Python install so core does not apply project's sources -> we need to configure pip index ourselves
-        urls: abc.Sequence[str] = project.module_source.urls
-        if not urls:
-            raise Exception("No package repos configured for project")
-        with env_vars(
-            {
-                "PIP_INDEX_URL": urls[0],
-                "PIP_PRE": "0" if project.install_mode == module.InstallMode.release else "1",
-                "PIP_EXTRA_INDEX_URL": " ".join(urls[1:]),
-            }
-        ):
-            project.virtualenv.install_from_source(paths)
+    with env_vars(pip_env_vars()):
+        subprocess.check_call(
+            [
+                # TODO: with current implementation this might reinstall (different versions of) inmanta packages
+                project.virtualenv.python_path,
+                "-m",
+                "pip",
+                "install",
+                # Trailing separator to explicitly tell pip we point to a local directory
+                *chain.from_iterable(["-e", os.path.join(mod.path, "")] for mod in v2_modules),
+            ],
+        )
 
 # Install all other dependencies
 LOGGER.info("Installing other project dependencies")
-project.install_modules()
+subprocess.check_call(
+    [project.virtualenv.python_path, "-m", "inmanta.app", "-vvv", "project", "install"],
+    cwd=str(project_path),
+)

--- a/src/pytest_inmanta_lsm/resources/setup_project.py
+++ b/src/pytest_inmanta_lsm/resources/setup_project.py
@@ -6,17 +6,15 @@ Pytest Inmanta LSM
 :license: Inmanta EULA
 """
 
-import contextlib
 import logging
 import os
 import pathlib
 import subprocess
 import sys
-from collections import abc
 from itertools import chain
-from typing import List, Optional
+from typing import Dict, List
 
-from inmanta import module
+from inmanta import env, module
 
 # The project_path has to be provided in env var
 project_path = pathlib.Path(os.environ["PROJECT_PATH"])
@@ -31,28 +29,13 @@ logging.root.setLevel(logging.DEBUG)
 LOGGER = logging.getLogger(project_path.name)
 
 
-@contextlib.contextmanager
-def env_vars(var: abc.Mapping[str, Optional[str]]) -> abc.Iterator[None]:
-    """
-    Context manager to extend the current environment with one or more environment variables.
-    A value of None means that the variable should be unset.
-    """
-
-    def set_env(set_var: abc.Mapping[str, Optional[str]]) -> None:
-        for name, value in set_var.items():
-            if value is not None:
-                os.environ[name] = value
-            elif name in os.environ:
-                del os.environ[name]
-
-    old_env: abc.Mapping = {name: os.environ.get(name, None) for name in var}
-    set_env(var)
-    yield
-    set_env(old_env)
-
-
 # Create the project object, this is the folder we sent to the orchestrator
 project = module.Project(str(project_path), venv_path=str(project_path / ".env"))
+
+# Make sure the venv the project should use exists.  We don't activate it, every
+# installation step is done in a subprocess, using the venv's python interpreter.
+assert isinstance(project.virtualenv, env.VirtualEnv), type(project.virtualenv)
+project.virtualenv.init_env()
 
 v2_modules: List[module.ModuleV2] = []
 # Discover all modules in the libs folder and install the v2 ones
@@ -80,41 +63,56 @@ for dir in (project_path / "libs").iterdir():
     LOGGER.info(f"Module {mod.name} is v2, we will attempt to install it")
 
 
-# TODO: do we need all this? It's based on inmanta.env, but we are in a simpler context here
-def pip_env_vars() -> abc.Mapping[str, Optional[str]]:
+def pip_env_vars() -> Dict[str, str]:
     """
-    Compute the environment variables that make pip install from the package sources
-    configured on the project.  We call pip ourselves, so core doesn't apply the project's
-    sources for us and we have to configure the pip index ourselves.
+    Compute the environment the pip process should run with.  We call pip ourselves, so core
+    doesn't apply the project's pip config for us, we have to translate it into pip
+    environment variables ourselves.  This is the same translation as the one core applies
+    when it installs modules itself.
     """
-    # The pip section of the project config is the authoritative package source
     pip_config = project.metadata.pip
-    return {
-        # Only take the config of this host into account when the project allows it
-        "PIP_CONFIG_FILE": None if pip_config.use_system_config else os.devnull,
-        "PIP_INDEX_URL": pip_config.index_url,
-        "PIP_EXTRA_INDEX_URL": " ".join(pip_config.extra_index_url) or None,
-        "PIP_PRE": None if pip_config.pre is None else str(pip_config.pre),
-        # No index to install from, the dependencies are expected to be installed already
-        "PIP_NO_INDEX": "1" if not pip_config.index_url and not pip_config.use_system_config else None,
-    }
+    sub_env = dict(os.environ)
+
+    if not pip_config.use_system_config:
+        # The project doesn't allow us to use the config of this host, drop it
+        for var in ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL", "PIP_PRE", "PIP_NO_INDEX"):
+            sub_env.pop(var, None)
+        sub_env["PIP_CONFIG_FILE"] = os.devnull
+
+        if not pip_config.index_url:
+            # There is no index we may install from, all the dependencies of the modules
+            # we install are expected to be installed already
+            sub_env["PIP_NO_INDEX"] = "1"
+
+    if pip_config.index_url:
+        sub_env["PIP_INDEX_URL"] = pip_config.index_url
+    if pip_config.extra_index_url:
+        sub_env["PIP_EXTRA_INDEX_URL"] = " ".join(pip_config.extra_index_url)
+    if pip_config.pre is not None:
+        # Only enforce the option if the project is explicit about it, otherwise let the
+        # config of this host, if any, decide
+        sub_env["PIP_PRE"] = str(pip_config.pre)
+
+    return sub_env
 
 
 # Install all v2 modules in editable mode using the project's configured package sources
 if v2_modules:
     LOGGER.info(f"Installing modules from source: {[mod.name for mod in v2_modules]}")
-    with env_vars(pip_env_vars()):
-        subprocess.check_call(
-            [
-                # TODO: with current implementation this might reinstall (different versions of) inmanta packages
-                project.virtualenv.python_path,
-                "-m",
-                "pip",
-                "install",
-                # Trailing separator to explicitly tell pip we point to a local directory
-                *chain.from_iterable(["-e", os.path.join(mod.path, "")] for mod in v2_modules),
-            ],
-        )
+    subprocess.check_call(
+        [
+            project.virtualenv.python_path,
+            "-m",
+            "pip",
+            "install",
+            # Trailing separator to explicitly tell pip we point to a local directory
+            *chain.from_iterable(["-e", os.path.join(mod.path, "")] for mod in v2_modules),
+            # The project venv inherits the packages of the orchestrator's venv, pin the inmanta
+            # ones to make sure we never install another version of them next to it
+            *(str(requirement) for requirement in env.ActiveEnv._get_requirements_on_inmanta_package()),
+        ],
+        env=pip_env_vars(),
+    )
 
 # Install all other dependencies
 LOGGER.info("Installing other project dependencies")


### PR DESCRIPTION
# Description

Install the project we sync to the remote orchestrator by calling `pip` and `inmanta project install` ourselves, in subprocesses running the project venv's python interpreter, instead of driving the installation with the inmanta core python api in the process running the install script.  This removes the need to activate the project venv in the install script, and the version-dependent branching that came with it.

Because we call pip ourselves, core doesn't apply the project's pip config for us, so the script translates that config into pip environment variables, the same way core does:
- the pip config of the host (config file, `PIP_*` env vars) is only taken into account when the project sets `pip.use-system-config`;
- when the project doesn't configure any index and doesn't allow the host config, `PIP_NO_INDEX` is set, i.e. all dependencies are expected to be installed already;
- `PIP_PRE` is only forced when the project is explicit about it.

The editable install of the v2 modules also pins the inmanta packages of the orchestrator (as core does through `add_inmanta_requires`), so it can never install another version of them in the project venv, next to the ones it inherits from the orchestrator's venv.

The pre-iso7 fallback is dropped.  The remaining code path relies on `project.metadata.pip`, which exists since inmanta-core 9 (iso6), so this only drops support for orchestrators older than iso6.

## Why the first version didn't work

The `project.use_virtual_env()` call was removed (we no longer need the venv activated in the install script's process), but nothing created the venv anymore, so both subprocess calls failed immediately on a fresh environment:

```
FileNotFoundError: [Errno 2] No such file or directory: '<project>/.env/bin/python'
```

The script now creates it explicitly with `VirtualEnv.init_env()`, which also writes the `.pth` file that makes the project venv inherit the orchestrator's venv, without activating anything in the current process.

## How it was verified

Reproduced and validated locally by running the install script the same way `RemoteOrchestrator.install_project` does (`<orchestrator python> .inm_lsm_setup_project.py` with `PROJECT_PATH` set) against a project containing a v2 module, for these cases:
- fresh project (no `.env`) and re-run over an existing `.env`;
- project without any v2 module in `libs`;
- `pip.index-url` set, `pip.use-system-config: true` without index, and no source at all (correctly fails with `no index`);
- the resulting `.env` contains exactly the same packages as the one produced by the current `master` version of the script, in particular no inmanta package is installed next to the inherited ones.

Note on CI: the `tests` stage failures are pre-existing on `master` (identical `5 passed, 10 errors`).  They come from the `module_v2_venv` test fixture, where pip 26.2's build isolation drops the stdlib from `sys.path` because of inmanta's venv inheritance `.pth` file, unrelated to this change.

closes *n/a*

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (the existing integration test suite covers the project install on a real orchestrator, no new test case added)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: n/a)
