### PR TITLE
Restore dataclass pairing on reused compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.3.0 - ?
 
 - Add `RemoteOrder` (and its async variant `remote_order_async.RemoteOrder`) to create, update and delete service instances through the orchestrator order API.
+- Fix compiler reuse (`--lsm-reuse-compiler`) breaking dataclass entities in tests that compile more than one model text: the pairing between a dsl dataclass entity and its python counterpart is restored before every reused compile, and two model texts that only differ in their surrounding newlines (as produced by `LsmProject.post_partial_compile_validation`) now share a single cached program.
 - Add opt-in compiler reuse for the `lsm_project` fixture (`--lsm-reuse-compiler` / `INMANTA_LSM_REUSE_COMPILER` / `lsm_reuse_compiler` fixture): parse and type-check the model only once and reuse the typed program for every subsequent compile of that same model, significantly speeding up model tests that perform many compiles. While active, it also disables the redundant on-disk parser cache, removing the cost of writing every module's `.cfc` during the cold compile.
 
 

--- a/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
+++ b/examples/test-multi-version/inmanta_plugins/test_multi_version/__init__.py
@@ -5,3 +5,22 @@ Pytest Inmanta LSM
 :contact: code@inmanta.com
 :license: Inmanta EULA
 """
+
+import dataclasses
+
+from inmanta.plugins import plugin
+
+
+@dataclasses.dataclass(frozen=True)
+class Tag:
+    name: str
+
+
+@plugin
+def tags(name: "string") -> "test_multi_version::Tag[]":
+    return [Tag(name=name)]
+
+
+@plugin
+def first_tag_name(tags: "test_multi_version::Tag[]") -> "string":
+    return tags[0].name

--- a/examples/test-multi-version/model/_init.cf
+++ b/examples/test-multi-version/model/_init.cf
@@ -96,9 +96,19 @@ implement Parent using parents
 implement Child using parents
 
 
+entity Tag extends std::Dataclass:
+    """ A dataclass entity, paired with its python counterpart in the plugins package. """
+    string name
+end
+
+implement Tag using std::none
+
+
 implementation tracer for lsm::ServiceEntity:
     tester = std::testing::NullResource(
-        name=self.name,
+        # Go through a plugin returning dataclass instances, so that the pairing between
+        # the Tag entity and its python counterpart is exercised on every compile.
+        name=first_tag_name(tags(self.name)),
     )
     self.resources += tester
     self.owned_resources += tester

--- a/examples/test-multi-version/setup.cfg
+++ b/examples/test-multi-version/setup.cfg
@@ -12,7 +12,7 @@ zip_safe=False
 include_package_data=True
 packages=find_namespace:
 install_requires =
-    inmanta-module-std>=3.1
+    inmanta-module-std>=8.3
     inmanta-module-lsm>=2.19
 
 [options.packages.find]

--- a/examples/test-multi-version/tests/test_dataclass.py
+++ b/examples/test-multi-version/tests/test_dataclass.py
@@ -1,0 +1,69 @@
+"""
+Pytest Inmanta LSM
+
+:copyright: 2026 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
+"""
+
+import textwrap
+
+import pytest_inmanta_lsm.lsm_project
+
+
+def test_compile_multiple_model_texts(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
+    """
+    Compiling more than one model text in the same test must not break the pairing between
+    the dsl dataclass entities and their python counterpart: the pairing is a process-global
+    that is only written during the typing phase, which compiler reuse skips.
+    """
+    model = "import test_multi_version"
+    lsm_project.export_service_entities(model)
+
+    service = lsm_project.create_service(
+        service_entity_name="parent",
+        attributes={"name": "parent", "description": "my-description"},
+        auto_transfer=True,
+    )
+    lsm_project.compile(service_id=service.id, validation=False)
+
+    # Compiling a different model text loads and types a second program, which rebinds the
+    # pairing of every dataclass entity to that second program.
+    lsm_project.exporting_compile(model=model + "\nimport std::testing")
+
+    # Going back to the first model text must still work.
+    lsm_project.compile(service_id=service.id, validation=False)
+
+
+def test_post_partial_compile_validation(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None:
+    """
+    post_partial_compile_validation compiles the content of main.cf, which is the model text
+    normalised by Project.compile.  That text must be recognised as the model that is already
+    loaded, and the compiles that follow it must keep working.
+    """
+    # The closing triple quote is indented, so the normalisation that Project.compile applies
+    # to this text is not idempotent: the text written to main.cf differs from the text a
+    # compile of that file's content would use.
+    model = """
+        import test_multi_version
+    """
+    assert model != textwrap.dedent(model.strip("\n"))
+
+    lsm_project.export_service_entities(model)
+    lsm_project.partial_compile = True
+
+    service = lsm_project.create_service(
+        service_entity_name="parent",
+        attributes={"name": "parent", "description": "my-description"},
+        auto_transfer=True,
+    )
+    lsm_project.compile(service_id=service.id, validation=False)
+    lsm_project.post_partial_compile_validation(
+        service.id,
+        shared_resource_patterns=[],
+        owned_resource_patterns=[".*"],
+    )
+
+    # The compiles that follow the validation must still work.
+    service.state = "up"
+    lsm_project.compile(service_id=service.id, validation=False)

--- a/src/pytest_inmanta_lsm/compile_cache.py
+++ b/src/pytest_inmanta_lsm/compile_cache.py
@@ -26,7 +26,9 @@ cost of writing every module's ``.cfc`` during the single cold compile.  Each
 subsequent ("warm") compile skips parse and ``define_types`` and only:
 
     * resets the per-compile *execution* state that the previous compile left on
-      the shared typed graph, and
+      the shared typed graph,
+    * restores the process-global state that the typing phase would have written
+      (the pairing between dataclass entities and their python counterpart), and
     * re-runs the execution phase (which re-reads the LSM data and re-emits the
       resources).
 
@@ -127,10 +129,10 @@ class CompileCache:
         shape.  Raise :class:`CompilerReuseUnavailableError` otherwise.
         """
         try:
-            import inmanta.ast.entity  # noqa: F401
             import inmanta.ast.statements.define  # noqa: F401
             import inmanta.compiler as compiler_mod
             import inmanta.execute.runtime  # noqa: F401
+            from inmanta.ast.entity import Entity
             from inmanta.compiler import config as compiler_config
             from inmanta.execute import scheduler as scheduler_mod
             from pytest_inmanta.plugin import Project as PytestInmantaProject
@@ -153,6 +155,8 @@ class CompileCache:
             (compiler_config.feature_compiler_cache, "get"),
             (scheduler_mod.Scheduler, "define_types"),
             (scheduler_mod.Scheduler, "run"),
+            (Entity, "get_paired_dataclass"),
+            (Entity, "pair_dataclass_stage1"),
             (PytestInmantaProject, "_create_project_and_load"),
         ]
         for owner, name in required:
@@ -186,15 +190,16 @@ class CompileCache:
         orig_define_types = scheduler_mod.Scheduler.define_types
 
         def create_project_and_load(pi_project: PytestInmantaProject, model: str) -> Project:
-            state = self._states.get(model)
+            key = self._cache_key(model)
+            state = self._states.get(key)
             if state is not None and state.compiled:
                 # Warm: reuse the already parsed and typed project, so its AST is
                 # not rebuilt and the parser cache is not read again.
                 compiler_mod.module.Project.set(state.project, clean=False)
                 return state.project
             project = orig_create(pi_project, model)
-            self._states[model] = _TypedProgram(project)
-            setattr(project, self._MODEL_TAG, model)
+            self._states[key] = _TypedProgram(project)
+            setattr(project, self._MODEL_TAG, key)
             return project
 
         def define_types(
@@ -265,6 +270,7 @@ class CompileCache:
         # does this); do the same so e.g. lsm's partial-compile selector cache
         # starts fresh for this compile.
         compiler_mod.ProjectLoader._reset_module_state()
+        self._restore_dataclass_pairing(state)
         self._reset_execution_state(state)
 
         assert state.root_ns is not None  # guaranteed once state.compiled is True
@@ -291,6 +297,40 @@ class CompileCache:
             self._warm_schedulers.discard(id(sched))
             compiler_mod.Finalizers.call_finalizers(raised)
         return state.types, state.root_ns
+
+    @staticmethod
+    def _cache_key(model: str) -> str:
+        """
+        Canonical form of a model text, used to identify a cached typed program.
+
+        ``Project.compile`` normalises the model it is given with ``dedent(model.strip("\\n"))``
+        before writing it to ``main.cf``.  That normalisation is not idempotent: a model whose
+        literal ends with a whitespace-only line (the usual style when the closing triple quote
+        is indented) gets a trailing newline that a second round through ``Project.compile``
+        strips again.  Reading ``main.cf`` back and compiling its content, as
+        ``LsmProject.post_partial_compile_validation`` does, would then start a second program
+        for what is the same model.  Stripping the surrounding newlines is enough to make both
+        texts map to the same entry, and never merges two models that differ in anything else.
+        """
+        return model.strip("\n")
+
+    @staticmethod
+    def _restore_dataclass_pairing(state: _TypedProgram) -> None:
+        """
+        Re-point every dataclass of the reused program's entities at that program.
+
+        The pairing between a dsl dataclass entity and its python counterpart is stored
+        on the *python class* (a process-global), and it is only written during the
+        typing phase, which a warm compile skips.  Any compile of a different model text
+        types a second program and rebinds that global to the entities of that program,
+        so a plugin returning dataclass instances would build them from the other
+        program's entity while its declared return type still resolves to this one.
+        """
+        from inmanta.ast.entity import Entity
+
+        for entity in state.types.values():
+            if isinstance(entity, Entity) and entity.get_paired_dataclass() is not None:
+                entity.pair_dataclass_stage1()
 
     @staticmethod
     def _all_namespaces(root_ns: Namespace) -> typing.Iterator[Namespace]:

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1,0 +1,36 @@
+"""
+Pytest Inmanta LSM
+
+:copyright: 2026 Inmanta
+:contact: code@inmanta.com
+:license: Inmanta EULA
+"""
+
+import textwrap
+
+from pytest_inmanta_lsm.compile_cache import CompileCache
+
+
+def test_cache_key_normalisation_round_trip() -> None:
+    """
+    A model text that went through the normalisation of Project.compile, and is then compiled
+    again (which is what LsmProject.post_partial_compile_validation does with the content of
+    main.cf), must be recognised as the same model.
+    """
+    # A model literal whose closing triple quote is indented, the usual style inside a test.
+    model = """
+        import std
+    """
+
+    # What Project.compile writes to main.cf, and what a compile of that content normalises to.
+    written = textwrap.dedent(model.strip("\n"))
+    recompiled = textwrap.dedent(written.strip("\n"))
+    assert written != recompiled
+
+    assert CompileCache._cache_key(written) == CompileCache._cache_key(recompiled)
+
+
+def test_cache_key_keeps_different_models_apart() -> None:
+    """Only the surrounding newlines are normalised away."""
+    assert CompileCache._cache_key("import std") != CompileCache._cache_key("import std\nimport std::testing")
+    assert CompileCache._cache_key("import std") != CompileCache._cache_key("    import std")

--- a/tests/test_multi_version.py
+++ b/tests/test_multi_version.py
@@ -51,3 +51,13 @@ def test_basic_example_reuse_compiler(testdir, module_venv_active):
 
     result = testdir.runpytest("tests/test_basics.py", "--lsm-reuse-compiler")
     result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("reuse_compiler", [False, True])
+def test_multiple_model_texts(testdir, module_venv_active, reuse_compiler: bool):
+    """Compiling more than one model text keeps the dataclass entity pairing intact."""
+
+    utils.add_version_constraint_to_project(testdir.tmpdir)
+
+    result = testdir.runpytest("tests/test_dataclass.py", *(["--lsm-reuse-compiler"] if reuse_compiler else []))
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
# Description

With `--lsm-reuse-compiler`, a test that compiles more than one model text broke every subsequent compile with `PluginTypeException: ... has incompatible type. Expected type: <same name>[]` as soon as the model used `std::Dataclass` entities and a plugin returned them.

The pairing between a dsl dataclass entity and its python counterpart lives on the *python class* (`_paired_inmanta_entity`, a process-global) and is only written during the typing phase. A warm compile skips typing, so a compile of a different model text types a second program and rebinds that global; the reused program's plugin signatures then resolve to entities the instances no longer come from.

Two changes:

* `_warm_compile` restores the pairing of the reused program's dataclass entities before running, the same way it already restores execution state.
* The model text used as cache key is canonicalised (surrounding newlines stripped), so the text `Project.compile` writes to `main.cf` and the text a compile of that file's content normalises to map to the same cached program. This is what made `LsmProject.post_partial_compile_validation` hit the bug on every call.

Tests: the `test-multi-version` example gained a `std::Dataclass` entity plus a plugin returning instances of it (exercised on every compile), and two test cases covering the two ways to reach a second program — a second explicit model text, and `post_partial_compile_validation`. Both fail on master with the reported error and pass with this change; they also run with compiler reuse disabled. `tests/test_compile_cache.py` pins the cache-key normalisation.

closes #577

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- ~~End user documentation is included or an issue is created for end-user documentation~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)