### PR TITLE
Use the instance's service entity version on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.3.0 - ?
 
+- Fix `LsmProject.update_service` using the default version of the service entity instead of the version of the instance being updated, which made it impossible to update an instance whose `service_entity_version` is not the default one.
 - Add `RemoteOrder` (and its async variant `remote_order_async.RemoteOrder`) to create, update and delete service instances through the orchestrator order API.
 - Fix compiler reuse (`--lsm-reuse-compiler`) breaking dataclass entities in tests that compile more than one model text: the pairing between a dsl dataclass entity and its python counterpart is restored before every reused compile, and two model texts that only differ in their surrounding newlines (as produced by `LsmProject.post_partial_compile_validation`) now share a single cached program.
 - Add opt-in compiler reuse for the `lsm_project` fixture (`--lsm-reuse-compiler` / `INMANTA_LSM_REUSE_COMPILER` / `lsm_reuse_compiler` fixture): parse and type-check the model only once and reuse the typed program for every subsequent compile of that same model, significantly speeding up model tests that perform many compiles. While active, it also disables the redundant on-disk parser cache, removing the cost of writing every module's `.cfc` during the cold compile.

--- a/examples/test-multi-version/tests/test_basics.py
+++ b/examples/test-multi-version/tests/test_basics.py
@@ -69,6 +69,17 @@ def test_compile(lsm_project: pytest_inmanta_lsm.lsm_project.LsmProject) -> None
     service.state = "up"
     lsm_project.compile(service_id=service.id)
 
+    # Update the child service, its own service entity version (0) should be used, not the
+    # default one (1), which has an additional required attribute
+    lsm_project.update_service(
+        service_id=service.id,
+        attributes=copy.deepcopy(service.active_attributes),
+        auto_transfer=True,
+    )
+
+    # Assert that the service has been updated and is now in update_inprogress state
+    assert service.state == "update_inprogress"
+
     # Create a child service without providing a service_entity_version
     service = lsm_project.create_service(
         service_entity_name="child",

--- a/src/pytest_inmanta_lsm/lsm_project.py
+++ b/src/pytest_inmanta_lsm/lsm_project.py
@@ -914,7 +914,7 @@ class LsmProject:
         """
         # Get the service and its corresponding service entity
         service = self.get_service(service_id)
-        service_entity = self.get_service_entity(service.service_entity, attributes.get("service_entity_version", None))
+        service_entity = self.get_service_entity(service.service_entity, service.service_entity_version)
 
         # Go into the update state
         try:


### PR DESCRIPTION
# Description

`LsmProject.update_service` resolved the service entity version from the `attributes` dict (`attributes.get("service_entity_version", None)`), but `service_entity_version` is a field of `ServiceInstance`, not one of its attributes.  The lookup therefore always returned `None` and `get_service_entity` fell back to the **default** version of the entity.

Updating an instance whose `service_entity_version` is not the default one consequently:
- used the lifecycle of the wrong entity version to look up the `ON_UPDATE` transfer;
- validated the attributes against the wrong entity version, raising `AttributeValidationFailed` as soon as the two versions don't share the same attributes.

The fix uses `service.service_entity_version`, like every other call site in the class (`auto_transfer`, `exporting_services`, ...).

The `test-multi-version` example now updates its version-0 `child` instance (the version without the required `description` attribute that version 1 has).  Without the fix that test fails with `inmanta_lsm.validation_type.AttributeValidationFailed`.

closes #582

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)
